### PR TITLE
timecraft: rename store to registry

### DIFF
--- a/internal/cmd/replay.go
+++ b/internal/cmd/replay.go
@@ -18,17 +18,17 @@ const replayUsage = `
 Usage:	timecraft replay [options] <process id>
 
 Options:
-   -h, --help        Show this usage information
-       --store path  Path to the timecraft object store (default to ~/.timecraft)
+   -h, --help           Show this usage information
+   -r, --registry path  Path to the timecraft registry (default to ~/.timecraft)
 `
 
 func replay(ctx context.Context, args []string) error {
 	var (
-		store = "~/.timecraft"
+		registryPath = "~/.timecraft"
 	)
 
 	flagSet := newFlagSet("timecraft replay", replayUsage)
-	flagSet.StringVar(&store, "store", store, "")
+	stringVar(flagSet, &registryPath, "r", "registry")
 	flagSet.Parse(args)
 
 	args = flagSet.Args()
@@ -41,29 +41,29 @@ func replay(ctx context.Context, args []string) error {
 		return errors.New(`malformed process id passed as argument (not a UUID)`)
 	}
 
-	timestore, err := openStore(store)
+	registry, err := openRegistry(registryPath)
 	if err != nil {
 		return err
 	}
 
-	manifest, err := timestore.LookupLogManifest(ctx, processID)
+	manifest, err := registry.LookupLogManifest(ctx, processID)
 	if err != nil {
 		return err
 	}
-	process, err := timestore.LookupProcess(ctx, manifest.Process.Digest)
+	process, err := registry.LookupProcess(ctx, manifest.Process.Digest)
 	if err != nil {
 		return err
 	}
-	config, err := timestore.LookupConfig(ctx, process.Config.Digest)
+	config, err := registry.LookupConfig(ctx, process.Config.Digest)
 	if err != nil {
 		return err
 	}
-	module, err := timestore.LookupModule(ctx, config.Modules[0].Digest)
+	module, err := registry.LookupModule(ctx, config.Modules[0].Digest)
 	if err != nil {
 		return err
 	}
 
-	logSegment, err := timestore.ReadLogSegment(ctx, processID, 0)
+	logSegment, err := registry.ReadLogSegment(ctx, processID, 0)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -108,7 +108,7 @@ func (s *stringList) Set(value string) error {
 	return nil
 }
 
-func createStore(path string) (*timemachine.Store, error) {
+func createRegistry(path string) (*timemachine.Registry, error) {
 	path, err := resolvePath(path)
 	if err != nil {
 		return nil, err
@@ -118,10 +118,10 @@ func createStore(path string) (*timemachine.Store, error) {
 			return nil, err
 		}
 	}
-	return openStore(path)
+	return openRegistry(path)
 }
 
-func openStore(path string) (*timemachine.Store, error) {
+func openRegistry(path string) (*timemachine.Registry, error) {
 	path, err := resolvePath(path)
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func openStore(path string) (*timemachine.Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	return timemachine.NewStore(dir), nil
+	return timemachine.NewRegistry(dir), nil
 }
 
 func resolvePath(path string) (string, error) {


### PR DESCRIPTION
Renaming to reduce the name overload between `internal/object` and `internal/timemachine`