### PR TITLE
timecraft: add more details when describing modules

### DIFF
--- a/internal/cmd/describe.go
+++ b/internal/cmd/describe.go
@@ -513,17 +513,17 @@ func (desc *moduleDescriptor) Format(w fmt.State, _ rune) {
 	if len(desc.imports.functions)+len(desc.exports.functions) > 0 {
 		fmt.Fprintf(w, "\n")
 		fw := textprint.NewTableWriter[functionDefinition](w)
-		fw.Write(desc.imports.functions)
-		fw.Write(desc.exports.functions)
-		fw.Close()
+		_, _ = fw.Write(desc.imports.functions)
+		_, _ = fw.Write(desc.exports.functions)
+		_ = fw.Close()
 	}
 
 	if len(desc.imports.memories)+len(desc.exports.memories) > 0 {
 		fmt.Fprintf(w, "\n")
 		mw := textprint.NewTableWriter[memoryDefinition](w)
-		mw.Write(desc.imports.memories)
-		mw.Write(desc.exports.memories)
-		mw.Close()
+		_, _ = mw.Write(desc.imports.memories)
+		_, _ = mw.Write(desc.exports.memories)
+		_ = mw.Close()
 	}
 }
 


### PR DESCRIPTION
This PR enhances the description of modules stored in the time machine registry.

See for example:
```
$ ./timecraft describe mod 74080192e42e
ID:   sha256:74080192e42e359ae621d939f2b7bb56072f94dce757c42c5de666f25f101aff
Name: (none)
Size: 6.82 MiB

SECTION  MODULE                  FUNCTION               SIGNATURE
import   wasi_snapshot_preview1  args_get               (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  args_sizes_get         (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  clock_time_get         (func (param i32) (param i64) (param i32) (result i32))
import   wasi_snapshot_preview1  environ_get            (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  environ_sizes_get      (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  fd_close               (func (param i32) (result i32))
import   wasi_snapshot_preview1  fd_fdstat_get          (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  fd_fdstat_set_flags    (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  fd_filestat_get        (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  fd_prestat_dir_name    (func (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  fd_prestat_get         (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  fd_read                (func (param i32) (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  fd_readdir             (func (param i32) (param i32) (param i32) (param i64) (param i32) (result i32))
import   wasi_snapshot_preview1  fd_write               (func (param i32) (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  fd_write               (func (param i32) (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  path_filestat_get      (func (param i32) (param i32) (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  path_open              (func (param i32) (param i32) (param i32) (param i32) (param i32) (param i64) (param i64) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  path_readlink          (func (param i32) (param i32) (param i32) (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  path_remove_directory  (func (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  path_unlink_file       (func (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  poll_oneoff            (func (param i32) (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  proc_exit              (func (param i32))
import   wasi_snapshot_preview1  random_get             (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  random_get             (func (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  sched_yield            (func (result i32))
import   wasi_snapshot_preview1  sock_accept            (func (param i32) (param i32) (param i32) (result i32))
import   wasi_snapshot_preview1  sock_shutdown          (func (param i32) (param i32) (result i32))
export   (none)                  _start                 (func)

SECTION  MODULE  MEMORY  MIN SIZE  MAX SIZE
export   (none)  memory  19 MiB    4 GiB
```