### PR TITLE
timecraft: fix run from default config

### DIFF
--- a/config.go
+++ b/config.go
@@ -155,18 +155,18 @@ func value[T any](v T) nullable[T] {
 	return nullable[T]{value: v, exist: true}
 }
 
-func (v *nullable[T]) Value() (T, bool) {
+func (v nullable[T]) Value() (T, bool) {
 	return v.value, v.exist
 }
 
-func (v *nullable[T]) MarshalJSON() ([]byte, error) {
+func (v nullable[T]) MarshalJSON() ([]byte, error) {
 	if !v.exist {
 		return []byte("null"), nil
 	}
 	return json.Marshal(v.value)
 }
 
-func (v *nullable[T]) MarshalYAML() (any, error) {
+func (v nullable[T]) MarshalYAML() (any, error) {
 	if !v.exist {
 		return nil, nil
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,7 @@ func TestTimecraft(t *testing.T) {
 	t.Run("get", get.run)
 	t.Run("help", help.run)
 	t.Run("root", root.run)
+	t.Run("run", run.run)
 	t.Run("unknown", unknown.run)
 	t.Run("version", version.run)
 }

--- a/run_test.go
+++ b/run_test.go
@@ -1,0 +1,33 @@
+package main_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stealthrocket/timecraft/internal/assert"
+)
+
+var run = tests{
+	"show the run command help with the short option": func(t *testing.T) {
+		stdout, stderr, err := timecraft(t, "run", "-h")
+		assert.OK(t, err)
+		assert.HasPrefix(t, stdout, "Usage:\ttimecraft run ")
+		assert.Equal(t, stderr, "")
+	},
+
+	"show the run command help with the long option": func(t *testing.T) {
+		stdout, stderr, err := timecraft(t, "run", "--help")
+		assert.OK(t, err)
+		assert.HasPrefix(t, stdout, "Usage:\ttimecraft run ")
+		assert.Equal(t, stderr, "")
+	},
+
+	"running with a configuration file which does not exist uses the default location": func(t *testing.T) {
+		t.Setenv("TIMECRAFTCONFIG", filepath.Join(t.TempDir(), "path", "to", "nowehere.yaml"))
+
+		stdout, stderr, err := timecraft(t, "run", "./testdata/go/sleep.wasm", "0")
+		assert.OK(t, err)
+		assert.Equal(t, stdout, "sleeping for 0s\n")
+		assert.NotEqual(t, stderr, "")
+	},
+}


### PR DESCRIPTION
The issues was due to `nullable[T]` not implementing `yaml.Marshaler`, resulting in the default configuration generated by timecraft to be invalid.