### PR TITLE
don't use the default configuration in tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -50,7 +50,11 @@ func (suite tests) run(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			b, err := yaml.Marshal(configuration{
 				Registry: registry{
-					Location: t.TempDir(),
+					// Add a "one/two" subdirectory because the path is unlikely
+					// to be used in the code, and it will detect a regression
+					// if using a non-existing directory causes the program to
+					// fail.
+					Location: filepath.Join(t.TempDir(), "one", "two"),
 				},
 				Cache: cache{
 					Location: os.Getenv("TIMECRAFT_TEST_CACHE"),

--- a/run_test.go
+++ b/run_test.go
@@ -1,7 +1,6 @@
 package main_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/stealthrocket/timecraft/internal/assert"
@@ -20,14 +19,5 @@ var run = tests{
 		assert.Equal(t, exitCode, 0)
 		assert.HasPrefix(t, stdout, "Usage:\ttimecraft run ")
 		assert.Equal(t, stderr, "")
-	},
-
-	"running with a configuration file which does not exist uses the default location": func(t *testing.T) {
-		t.Setenv("TIMECRAFTCONFIG", filepath.Join(t.TempDir(), "path", "to", "nowehere.yaml"))
-
-		stdout, stderr, exitCode := timecraft(t, "run", "./testdata/go/sleep.wasm", "0")
-		assert.Equal(t, exitCode, 0)
-		assert.Equal(t, stdout, "sleeping for 0s\n")
-		assert.NotEqual(t, stderr, "")
 	},
 }


### PR DESCRIPTION
Fix to not leak test data in the default registry.