### PR TITLE
timemachine: add record offset

### DIFF
--- a/internal/timemachine/log_test.go
+++ b/internal/timemachine/log_test.go
@@ -70,6 +70,14 @@ func TestReadRecordBatch(t *testing.T) {
 		firstOffset += int64(len(batch))
 	}
 
+	recordOffset := int64(0)
+	for _, batch := range batches {
+		for i := range batch {
+			batch[i].Offset = recordOffset
+			recordOffset++
+		}
+	}
+
 	reader := timemachine.NewLogReader(bytes.NewReader(buffer.Bytes()), startTime)
 	batchesRead := make([][]timemachine.Record, 0, len(batches))
 	for {

--- a/internal/timemachine/record.go
+++ b/internal/timemachine/record.go
@@ -11,6 +11,7 @@ import (
 
 // Record is a read-only record from the log.
 type Record struct {
+	Offset       int64
 	Time         time.Time
 	FunctionID   int
 	FunctionCall []byte


### PR DESCRIPTION
I originally imagined we would compute the record offsets where needed by indexing from the record batch first offset, but looking at how https://github.com/stealthrocket/timecraft/pull/43 and https://github.com/stealthrocket/timecraft/pull/49 are shaping up I think we might be better off with an offset field.
