### PR TITLE
timemachine: fix reading more than 2 record batches

### DIFF
--- a/internal/timemachine/log.go
+++ b/internal/timemachine/log.go
@@ -102,7 +102,8 @@ func (r *LogReader) ReadRecordBatch() (*RecordBatch, error) {
 		}
 
 		r.batch.Reset(r.startTime, r.batchFrame.Data, r.input)
-		r.nextByteOffset = 4 + r.batchFrame.Size() + r.batch.Size()
+		r.nextByteOffset += r.batchFrame.Size()
+		r.nextByteOffset += r.batch.CompressedSize()
 
 		if nextRecordOffset := r.batch.NextOffset(); nextRecordOffset >= r.nextRecordOffset {
 			r.nextRecordOffset = nextRecordOffset


### PR DESCRIPTION
The `nextByteOffset` value was assigned instead of incremented, so after reading 2 record batches it pointed at an invalid location.