### PR TITLE
timemachine: fix reading multiple record batches

### DIFF
--- a/internal/timemachine/log.go
+++ b/internal/timemachine/log.go
@@ -211,8 +211,11 @@ func (r *LogRecordReader) Read(records []Record) (int, error) {
 			}
 		}
 
-		if n > 0 || err != io.EOF {
-			return n, err
+		if n > 0 {
+			return n, nil
+		}
+		if err != io.EOF {
+			return 0, err
 		}
 
 		r.batch = nil


### PR DESCRIPTION
The stop for when to stop looping through record batches was incorrectly bubbling the `io.EOF` error indicating the end of the current batch.