### PR TITLE
tracing: represent http header fields with multiple values

### DIFF
--- a/internal/debug/tracing/http.go
+++ b/internal/debug/tracing/http.go
@@ -1,17 +1,17 @@
 package tracing
 
 type httpRequest struct {
-	Proto  string            `json:"protocol,omitempty" yaml:"protocol,omitempty"`
-	Method string            `json:"method,omitempty"   yaml:"method,omitempty"`
-	Path   string            `json:"path,omitempty"     yaml:"path,omitempty"`
-	Header map[string]string `json:"header,omitempty"   yaml:"header,omitempty"`
-	Body   Bytes             `json:"body,omitempty"     yaml:"body,omitempty"`
+	Proto  string              `json:"protocol,omitempty" yaml:"protocol,omitempty"`
+	Method string              `json:"method,omitempty"   yaml:"method,omitempty"`
+	Path   string              `json:"path,omitempty"     yaml:"path,omitempty"`
+	Header map[string][]string `json:"header,omitempty"   yaml:"header,omitempty"`
+	Body   Bytes               `json:"body,omitempty"     yaml:"body,omitempty"`
 }
 
 type httpResponse struct {
-	Proto      string            `json:"protocol,omitempty"   yaml:"protocol,omitempty"`
-	StatusCode int               `json:"statusCode,omitempty" yaml:"statusCode,omitempty"`
-	StatusText string            `json:"statusText,omitempty" yaml:"statusText,omitempty"`
-	Header     map[string]string `json:"header,omitempty"     yaml:"header,omitempty"`
-	Body       Bytes             `json:"body,omitempty"       yaml:"body,omitempty"`
+	Proto      string              `json:"protocol,omitempty"   yaml:"protocol,omitempty"`
+	StatusCode int                 `json:"statusCode,omitempty" yaml:"statusCode,omitempty"`
+	StatusText string              `json:"statusText,omitempty" yaml:"statusText,omitempty"`
+	Header     map[string][]string `json:"header,omitempty"     yaml:"header,omitempty"`
+	Body       Bytes               `json:"body,omitempty"       yaml:"body,omitempty"`
 }

--- a/internal/debug/tracing/http1.go
+++ b/internal/debug/tracing/http1.go
@@ -224,7 +224,7 @@ func (req *http1Request) Marshal() any {
 		Proto:  string(proto),
 		Method: string(method),
 		Path:   string(path),
-		Header: http1FormatHeader(header),
+		Header: http1MakeHeader(header),
 		Body:   Bytes(body),
 	}
 }
@@ -245,22 +245,16 @@ func (res *http1Response) Marshal() any {
 		Proto:      string(proto),
 		StatusCode: statusCode,
 		StatusText: string(statusText),
-		Header:     http1FormatHeader(header),
+		Header:     http1MakeHeader(header),
 		Body:       Bytes(body),
 	}
 }
 
-func http1FormatHeader(b []byte) map[string]string {
-	header := make(map[string]string)
+func http1MakeHeader(b []byte) map[string][]string {
+	header := make(map[string][]string)
 	http1HeaderRange(b, func(name, value []byte) bool {
 		k := textproto.CanonicalMIMEHeaderKey(string(name))
-		v, exist := header[k]
-		if exist {
-			v += ", " + string(value)
-		} else {
-			v = string(value)
-		}
-		header[k] = v
+		header[k] = append(header[k], string(value))
 		return true
 	})
 	return header


### PR DESCRIPTION
Follow up to @chriso's suggestion in https://github.com/stealthrocket/timecraft/pull/67, this PR changes the JSON/YAML output format of http messages to encode the header field values as an array.

I tried using an array of name/value pairs as well but I think the object notation is more useful for the cases where we'd want to use structured formatting (e.g. doing processing with `jq` or scripting languages, the object notation translates directly to a JavaScript object or Python dictionary, etc...).
