### PR TITLE
scheduler: fix deadlock on close

### DIFF
--- a/internal/timecraft/task.go
+++ b/internal/timecraft/task.go
@@ -295,7 +295,10 @@ func (s *TaskScheduler) completeTask(task *TaskInfo, err error, output TaskOutpu
 	})
 
 	if task.completions != nil {
-		task.completions <- task.id
+		select {
+		case <-s.ctx.Done():
+		case task.completions <- task.id:
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes a deadlock introduced in https://github.com/stealthrocket/timecraft/pull/88. When posting task completions to a channel, we need to bail from the operation when the scheduler's context is cancelled.