### PR TITLE
mac: fix retry when connecting to work socket

### DIFF
--- a/internal/timecraft/process.go
+++ b/internal/timecraft/process.go
@@ -248,7 +248,14 @@ func (pm *ProcessManager) Start(moduleSpec ModuleSpec, logSpec *LogSpec) (Proces
 				retry(ctx, maxAttempts, minDelay, maxDelay, func() bool {
 					var d net.Dialer
 					conn, err = d.DialContext(ctx, "unix", workSocket)
-					return err != nil && errors.Is(err, syscall.ECONNREFUSED)
+					if err == nil {
+						return false
+					}
+					var se syscall.Errno
+					if !errors.As(err, &se) {
+						return false
+					}
+					return se == syscall.ECONNREFUSED || se == syscall.ENOENT
 				})
 				return
 			},


### PR DESCRIPTION
Follow up to #87 — we need to retry on `syscall.ENOENT` too.