### PR TITLE
trace: fix header decoding with empty value

### DIFF
--- a/internal/debug/tracing/http1.go
+++ b/internal/debug/tracing/http1.go
@@ -422,9 +422,7 @@ func http1HeaderRange(header []byte, do func(name, value []byte) bool) []byte {
 			break
 		}
 		value, header = http1ParseFieldValue(header)
-		if len(value) == 0 {
-			break
-		}
+
 		if !do(name, value) {
 			break
 		}

--- a/internal/debug/tracing/http1_test.go
+++ b/internal/debug/tracing/http1_test.go
@@ -350,6 +350,15 @@ func TestHttp1HeaderRange(t *testing.T) {
 				{name: "Content-Type", value: "text/plain; charset=utf-8"},
 			},
 		},
+
+		{
+			scenario: "header with empty value",
+			input: "Accept-Encoding:\r\n" +
+				"\r\n",
+			fields: []field{
+				{name: "Accept-Encoding", value: ""},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Valid HTTP headers can have an empty value.

In our example, this happens with the `Accept-Encoding` header of the response in this exchange:

```
2023/06/23 09:12:16.164670 HTTP @ > @timecraft.sock
> POST /timecraft.server.v1.TimecraftService/LookupTasks HTTP/1.1
> Host: localhost
> User-Agent: python-requests/2.31.0
> Accept-Encoding: gzip, deflate
> Accept: */*
> Connection: keep-alive
> Content-Length: 52
> Content-Type: application/json
>
{"taskId": ["7d111ba3-3ded-4b99-a68c-61853d16b6a7"]}
< HTTP/1.1 200 OK
< Accept-Encoding:
< Content-Type: application/json
< Date: Fri, 23 Jun 2023 13:12:17 GMT
< Content-Length: 376
<
{"responses":[{"taskId":"7d111ba3-3ded-4b99-a68c-61853d16b6a7","state":"TASK_STATE_SUCCESS","processId":"831bf783-a5c0-45aa-90f8-d9ee92bf645e","httpResponse":{"statusCode":200,"headers":[{"name":"Date","value":"Fri, 23 Jun 2023 13:12:17 GMT"},{"name":"Content-Length","value":"14"},{"name":"Content-Type","value":"text/plain; charset=utf-8"}],"body":"SGVsbG8gZnJvbSBHbyE="}}]}
```