### PR TITLE
trace: display error when formatting exchanges

### DIFF
--- a/internal/debug/tracing/exchange.go
+++ b/internal/debug/tracing/exchange.go
@@ -18,11 +18,31 @@ type Request struct {
 	msg  ConnMessage
 }
 
+func (r Request) Format(w fmt.State, v rune) {
+	if r.msg != nil {
+		r.msg.Format(w, v)
+	} else if r.Err != nil {
+		fmt.Fprintf(w, "Request error: %s", r.Err.Error())
+	} else {
+		fmt.Fprint(w, "unknown")
+	}
+}
+
 type Response struct {
 	Time time.Duration
 	Span time.Duration
 	Err  error
 	msg  ConnMessage
+}
+
+func (r Response) Format(w fmt.State, v rune) {
+	if r.msg != nil {
+		r.msg.Format(w, v)
+	} else if r.Err != nil {
+		fmt.Fprintf(w, "Response error: %s", r.Err.Error())
+	} else {
+		fmt.Fprint(w, "unknown")
+	}
 }
 
 // Exchange values represent the exchange of a request and response between
@@ -42,14 +62,14 @@ func (e Exchange) Format(w fmt.State, v rune) {
 
 	if w.Flag('+') {
 		fmt.Fprintf(w, "\n")
-		e.Req.msg.Format(w, v)
-		e.Res.msg.Format(w, v)
+		e.Req.Format(w, v)
+		e.Res.Format(w, v)
 	} else {
 		fmt.Fprintf(w, ": ")
-		e.Req.msg.Format(w, v)
+		e.Req.Format(w, v)
 
 		fmt.Fprintf(w, " => ")
-		e.Res.msg.Format(w, v)
+		e.Res.Format(w, v)
 	}
 }
 


### PR DESCRIPTION
If for example a response resulted in an error instead of a message, it would display with a nil pointer panic:

```
timecraft trace req 090eee9c-6568-42ef-9113-28ca5e31023a
2023/06/23 09:12:17.678479 HTTP 127.0.0.1:35152 > 127.0.0.1:3000: POST /gokit => 200 OK
2023/06/23 09:12:15.654671 HTTP @ > @timecraft.sock: POST /timecraft.server.v1.TimecraftService/SubmitTasks => %!v(PANIC=Format method: runtime error: invalid memory address or nil pointer dereference)
2023/06/23 09:12:15.660024 HTTP @ > @timecraft.sock: POST /timecraft.server.v1.TimecraftService/LookupTasks => %!v(PANIC=Format method: runtime error: invalid memory address or nil pointer dereference)
2023/06/23 09:12:15.660037 HTTP @ > @timecraft.sock: POST /timecraft.server.v1.TimecraftService/LookupTasks => %!v(PANIC=Format method: runtime error: invalid memory address or nil pointer dereference)
```

Instead, let's fail a bit more gracefully:

```
timecraft trace req 090eee9c-6568-42ef-9113-28ca5e31023a
2023/06/23 09:12:17.678479 HTTP 127.0.0.1:35152 > 127.0.0.1:3000: POST /gokit => 200 OK
2023/06/23 09:12:15.654671 HTTP @ > @timecraft.sock: POST /timecraft.server.v1.TimecraftService/SubmitTasks => unexpected EOF
2023/06/23 09:12:15.660024 HTTP @ > @timecraft.sock: POST /timecraft.server.v1.TimecraftService/LookupTasks => unexpected EOF
2023/06/23 09:12:15.660037 HTTP @ > @timecraft.sock: POST /timecraft.server.v1.TimecraftService/LookupTasks => unexpected EOF
```