### PR TITLE
debug: print stdin

### DIFF
--- a/internal/debug/stdio/reader.go
+++ b/internal/debug/stdio/reader.go
@@ -105,7 +105,7 @@ func (r *Reader) Read(b []byte) (n int, err error) {
 				}
 				switch fd {
 				case r.stdin:
-					writeIOVecs(&r.buffer, iovecs, size)
+					r.writeIOVecs(iovecs, size)
 				}
 
 			case wasicall.FDWrite:
@@ -118,20 +118,20 @@ func (r *Reader) Read(b []byte) (n int, err error) {
 				}
 				switch fd {
 				case r.stdout, r.stderr:
-					writeIOVecs(&r.buffer, iovecs, size)
+					r.writeIOVecs(iovecs, size)
 				}
 			}
 		}
 	}
 }
 
-func writeIOVecs(output io.Writer, iovecs []wasi.IOVec, size wasi.Size) {
+func (r *Reader) writeIOVecs(iovecs []wasi.IOVec, size wasi.Size) {
 	for _, iov := range iovecs {
 		iovLen := wasi.Size(len(iov))
 		if iovLen > size {
 			iovLen = size
 		}
 		size -= iovLen
-		output.Write(iov[:iovLen])
+		r.buffer.Write(iov[:iovLen])
 	}
 }


### PR DESCRIPTION
This makes the log output of programs that read from stdin more meaningful:

Before/After:
```
$ timecraft logs 9ac82fea-0c0b-42ae-a567-7cef8b9e7816
Python 3.11.3 (main, Jun 23 2023, 12:54:28) [Clang 15.0.7 ] on wasi
Type "help", "copyright", "credits" or "license" for more information.
>>> hello world!
>>>
```
```
$ timecraft logs 9ac82fea-0c0b-42ae-a567-7cef8b9e7816
Python 3.11.3 (main, Jun 23 2023, 12:54:28) [Clang 15.0.7 ] on wasi
Type "help", "copyright", "credits" or "license" for more information.
>>> print('hello world!')
hello world!
>>>
```