### PR TITLE
sdk/python: create standard logger

### DIFF
--- a/sdk/python/src/timecraft/__init__.py
+++ b/sdk/python/src/timecraft/__init__.py
@@ -1,7 +1,6 @@
-from .client import TaskInput, TaskOutput
-from .client import TaskRequest, TaskResponse
-from .client import TaskState, TaskID, ProcessID
-from .client import HTTPRequest, HTTPResponse, Header
 from .client import Client
+from .client import TaskRequest, TaskResponse, TaskInput, TaskOutput, TaskState, TaskID
+from .client import HTTPRequest, HTTPResponse, Header
+from .client import ProcessID, ModuleSpec
 
 from .worker import start_worker

--- a/sdk/python/src/timecraft/client.py
+++ b/sdk/python/src/timecraft/client.py
@@ -118,14 +118,13 @@ class Client:
     Client to interface with the Timecraft server.
     """
 
-    _root = "http://0.0.0.0:3001/timecraft.server.v0.TimecraftService/"
+    _root = "http://0.0.0.0:3001/timecraft.server.v1.TimecraftService/"
 
     def __init__(self):
         self.session = requests.Session()
 
     def _rpc(self, endpoint, payload):
         r = self.session.post(self._root + endpoint, json=payload)
-        out = r.json()
 
         try:
             r.raise_for_status()
@@ -133,11 +132,12 @@ class Client:
             print("Request payload:")
             pprint(payload)
             print("Response object:")
-            pprint(out)
+            pprint(r.text)
             raise
 
-        return out
+        return r.json()
 
+    @property
     def logger(self):
         global ClientLogger
 

--- a/sdk/python/src/timecraft/worker.py
+++ b/sdk/python/src/timecraft/worker.py
@@ -7,8 +7,7 @@ def start_worker(handler):
     runtime. The provided handler should be a subclass of
     http.server.BaseHTTPRequestHandler."""
     client = Client()
-    logger = client.logger()
-    logger.info("starting worker")
+    client.logger.info("starting worker")
 
     server = HTTPServer(("0.0.0.0", 3000), handler)
     server.serve_forever()


### PR DESCRIPTION
#122, but for Python.

Example:

```
2023/06/28 04:44:04 - 48192ac4-2194-466c-ab77-1598c1c044f8 - listening on :5000
2023/06/28 04:44:15 - 48192ac4-2194-466c-ab77-1598c1c044f8 - submitted task to "pykit" with 14 byte payload: a11ef623-b166-4106-ac5e-fa60ded1647e
2023/06/28 04:44:17 - 222dbc3f-edec-4763-be69-96308ab301ba - starting worker
2023/06/28 04:44:17 - 222dbc3f-edec-4763-be69-96308ab301ba - pykit processing payload: {"name":"bar"}
2023/06/28 04:44:17 - 48192ac4-2194-466c-ab77-1598c1c044f8 - task a11ef623-b166-4106-ac5e-fa60ded1647e executed successfully in process 222dbc3f-edec-4763-be69-96308ab301ba (200 => pykit doing its job!)
```