### PR TITLE
timecraft: only allow the main module to bind the host network 

### DIFF
--- a/internal/sandbox/system_test.go
+++ b/internal/sandbox/system_test.go
@@ -206,8 +206,12 @@ func TestPollDeadline(t *testing.T) {
 }
 
 func TestSystemListenPortZero(t *testing.T) {
+	listen := sandbox.Listen(func(ctx context.Context, network, address string) (net.Listener, error) {
+		return net.Listen(network, address)
+	})
+
 	ctx := context.Background()
-	sys := sandbox.New()
+	sys := sandbox.New(listen)
 
 	lstn, err := sys.Listen(ctx, "tcp", "127.0.0.1:0")
 	assert.OK(t, err)

--- a/internal/timecraft/module.go
+++ b/internal/timecraft/module.go
@@ -42,6 +42,10 @@ type ModuleSpec struct {
 	// Trace is an optional writer that receives a trace of system calls
 	// made by the module.
 	Trace io.Writer
+
+	// Allow the module to bind to the host network when opening listening
+	// sockets.
+	HostNetworkBinding bool
 }
 
 // Key is a string that uniquely identifies the ModuleSpec.

--- a/internal/timecraft/process.go
+++ b/internal/timecraft/process.go
@@ -147,11 +147,16 @@ func (pm *ProcessManager) Start(moduleSpec ModuleSpec, logSpec *LogSpec) (Proces
 		sandbox.Time(time.Now),
 		sandbox.Rand(rand.Reader),
 		sandbox.Dial(dialer.DialContext),
-		sandbox.Listen(listen.Listen),
-		sandbox.ListenPacket(listen.ListenPacket),
 		sandbox.Resolver(net.DefaultResolver),
 		sandbox.IPv4Network(netip.PrefixFrom(netip.AddrFrom4(ipv4), ipv4NetMask)),
 		sandbox.IPv6Network(netip.PrefixFrom(netip.AddrFrom16(ipv6), ipv6NetMask)),
+	}
+
+	if moduleSpec.HostNetworkBinding {
+		options = append(options,
+			sandbox.Listen(listen.Listen),
+			sandbox.ListenPacket(listen.ListenPacket),
+		)
 	}
 
 	for _, dir := range moduleSpec.Dirs {

--- a/internal/timecraft/server.go
+++ b/internal/timecraft/server.go
@@ -82,11 +82,16 @@ func (s *Server) submitTask(req *v1.TaskRequest) (TaskID, error) {
 	moduleSpec := s.moduleSpec // inherit from the parent
 	moduleSpec.Dials = nil     // not supported
 	moduleSpec.Listens = nil   // not supported
+	moduleSpec.Stdin = nil     // task handlers receive no data on stdin
 	moduleSpec.Args = req.Module.Args
 	moduleSpec.Env = append(moduleSpec.Env[:len(moduleSpec.Env):len(moduleSpec.Env)], req.Module.Env...)
 	if path := req.Module.Path; path != "" {
 		moduleSpec.Path = path
 	}
+	// The task processes can only bind on their virtual network, we don't
+	// create bridges to the host network for them. Only timecraft can open
+	// connections and send requests to those processes.
+	moduleSpec.HostNetworkBinding = false
 
 	var logSpec *LogSpec
 	if s.logSpec != nil {

--- a/run.go
+++ b/run.go
@@ -113,6 +113,10 @@ func run(ctx context.Context, args []string) error {
 		Stdin:   os.Stdin,
 		Stdout:  os.Stdout,
 		Stderr:  os.Stderr,
+		// Allow the main module to open listening sockets on the host network
+		// so server applications can receive connections as if they were
+		// running outside of timecraft.
+		HostNetworkBinding: true,
 	}
 	if trace {
 		moduleSpec.Trace = os.Stderr


### PR DESCRIPTION
This should address the issues where multiple task processes binding the same port get conflicts.