### PR TITLE
timecraft: expose gRPC endpoint on port 7463 

### DIFF
--- a/internal/timecraft/process.go
+++ b/internal/timecraft/process.go
@@ -69,6 +69,8 @@ type ProcessInfo struct {
 }
 
 const (
+	timecraftServicePort = 7463
+
 	ipv4NetAddrNumBits = 32
 	ipv6NetAddrNumBits = 128
 
@@ -259,7 +261,7 @@ func (pm *ProcessManager) Start(moduleSpec ModuleSpec, logSpec *LogSpec) (Proces
 	// Setup a gRPC server for the module so that it can interact with the
 	// timecraft runtime.
 	server := pm.serverFactory.NewServer(pm.ctx, processID, moduleSpec, logSpec)
-	serverAddress := netip.AddrPortFrom(netip.AddrFrom4(ipv4), 3001)
+	serverAddress := netip.AddrPortFrom(netip.AddrFrom4(ipv4), timecraftServicePort)
 	serverListener, err := guest.Listen(pm.ctx, "tcp", serverAddress.String())
 	if err != nil {
 		return ProcessID{}, err

--- a/sdk/python/src/timecraft/client.py
+++ b/sdk/python/src/timecraft/client.py
@@ -118,7 +118,7 @@ class Client:
     Client to interface with the Timecraft server.
     """
 
-    _root = "http://0.0.0.0:3001/timecraft.server.v1.TimecraftService/"
+    _root = "http://0.0.0.0:7463/timecraft.server.v1.TimecraftService/"
 
     def __init__(self):
         self.session = requests.Session()

--- a/sdk/socket.go
+++ b/sdk/socket.go
@@ -3,7 +3,7 @@ package sdk
 // TimecraftAddress is the socket that timecraft guests connect to in order to
 // interact with the timecraft runtime on the host. Note that this is a
 // virtual socket.
-const TimecraftAddress = "0.0.0.0:3001"
+const TimecraftAddress = "0.0.0.0:7463"
 
 // WorkAddress is the socket that receives work from the timecraft runtime.
 // Note that this is a virtual socket.


### PR DESCRIPTION
Chosen because they are the hexadecimal ascii codes for "tc".