### PR TITLE
README: make commands copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ WebAssembly, see [Preparing Your Application][preparing].
 To try some of the examples, first compile them with this command:
 ```
 make testdata
-...
 ```
 
 The compilation created programs with the `.wasm` extension since they are


### PR DESCRIPTION
Remove the leading `$` so the commands can be copied directly from the copy icon:

![image](https://github.com/stealthrocket/timecraft/assets/865510/64e03654-0409-4e8f-b4e9-838e5b6306cd)
