### PR TITLE
wasi: fix comparison of socket option values

### DIFF
--- a/internal/timemachine/wasicall/replay.go
+++ b/internal/timemachine/wasicall/replay.go
@@ -1572,6 +1572,9 @@ func equalSocketOptionValue(a, b SocketOptionValue) bool {
 	case IntValue:
 		bv, ok := b.(IntValue)
 		return ok && av == bv
+	case BytesValue:
+		bv, ok := b.(BytesValue)
+		return ok && bytes.Equal(av, bv)
 	default:
 		return false
 	}

--- a/internal/timemachine/wasicall/wasi_test.go
+++ b/internal/timemachine/wasicall/wasi_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/stealthrocket/timecraft/internal/htls"
 	"github.com/stealthrocket/wasi-go"
 	"github.com/tetratelabs/wazero/sys"
 )
@@ -154,6 +155,7 @@ var syscalls = []Syscall{
 	&SockGetOptSyscall{FD: 1, Option: wasi.Broadcast, Value: wasi.IntValue(1), Errno: 0},
 	&SockGetOptSyscall{FD: 1, Option: ^wasi.SocketOption(0), Value: nil, Errno: 1},
 	&SockGetOptSyscall{},
+	&SockSetOptSyscall{FD: 1, Option: wasi.MakeSocketOption(htls.Level, htls.Option), Value: wasi.BytesValue("foo"), Errno: 0},
 	&SockSetOptSyscall{FD: 1, Option: wasi.Broadcast, Value: wasi.IntValue(1), Errno: 0},
 	&SockSetOptSyscall{FD: 1, Option: ^wasi.SocketOption(0), Value: nil, Errno: 1},
 	&SockSetOptSyscall{},


### PR DESCRIPTION
Applications that use hTLS couldn't be replayed. The `wasi.BytesValue` socket option value stored in the log wasn't being compared to the system call param correctly.