### PR TITLE
py: upload binaries to S3 bucket

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,6 +1,9 @@
 name: Python
 
-on: [push]
+on:
+  push:
+    paths:
+      - 'python/*'
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -29,6 +29,15 @@ jobs:
           path: |
             python/cpython/python.wasm
             python/cpython/usr/local/lib/python311.zip
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Copy build output to public S3
+        run: |
+          aws s3 cp python/cpython/python.wasm                 s3://timecraft/python/$GITHUB_SHA/python.wasm
+          aws s3 cp python/cpython/usr/local/lib/python311.zip s3://timecraft/python/$GITHUB_SHA/python311.zip
 
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -2,6 +2,10 @@ name: Python
 
 on: [push]
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   build_and_test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ make testdata
 The compilation created programs with the `.wasm` extension since they are
 compiled to WebAssembly. We will use the example program `get.wasm`, which
 makes a GET request to the URLs passed as arguments:
+
 ```
 $ timecraft run testdata/go/get.wasm https://eo3qh2ncelpc9q0.m.pipedream.net
 ffe47142-c3ad-4f61-a5e9-739ebf456332

--- a/python/Makefile
+++ b/python/Makefile
@@ -18,7 +18,7 @@ endif
 container.version ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell git describe --tags || echo '$(subst /,-,$(branch))$(commit_timestamp)$(commit)'))
 container.image ?= ghcr.io/stealthrocket/timecraft-python
 
-python.commit.long = $(git log --format=format:%H -n1 -- .)
+python.commit.long = $(shell git log --format=format:%H -n1 -- .)
 
 docker-build: 
 	docker build -f Dockerfile.timecraft -t $(container.image):$(container.version) .

--- a/python/README.md
+++ b/python/README.md
@@ -43,16 +43,11 @@ This will store the package (if available) in `./deps`, which is provided using
 
 ## Download
 
-Instead of building it yourself, you can download the artifact of the latest
-successful build on github:
+```
+make download
+```
 
-Go to [Actions][actions] -> Click on green build -> Click on artifact.
-
-Unzip the downloaded file, then adjust the paths of the examples above.
-
-
-[actions]: https://github.com/stealthrocket/timecraft/actions
-
+It retrieves the most recent build of python for the current branch.
 
 ## Build
 

--- a/python/download.sh
+++ b/python/download.sh
@@ -3,49 +3,14 @@
 set -e
 
 if [ -z "$1" ]; then
-    >&2 echo -e "$0 downloads pre-built WebAssembly python from github.\nProvide timecraft git sha to download."
+    >&2 echo -e "$0 downloads pre-built WebAssembly python from s3.\nProvide timecraft git sha to download."
     exit 1
 fi
 
 commit=$1
 
-if [[ $(grep --version|grep BSD) ]]; then
-    grep_match="grep -Eo" # bsd grep
-else
-    grep_match="grep -Po" # gnu grep
-fi
-
-
-echo "Downloading pre-built python.wasm from GitHub artifacts"
-
-run_id=$(gh api \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  "/repos/stealthrocket/timecraft/actions/runs?head_sha=${commit}" \
-    |${grep_match} 'workflow_id":61648424,.+?"url":".+?"' \
-    |${grep_match} '/[0-9]+' \
-    |${grep_match} '[0-9]+')
-
-
-echo "Run ID: ${run_id}"
-
-artifact_id=$(gh api \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  "/repos/stealthrocket/timecraft/actions/runs/${run_id}/artifacts" \
-		  | ${grep_match} '"artifacts":[{"id":[0-9]+,' \
-		  | ${grep_match} '[0-9]+')
-
-echo "Artifact ID: ${artifact_id}"
-
-gh api \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  /repos/stealthrocket/timecraft/actions/artifacts/${artifact_id}/zip > /tmp/timecraft-python.zip
-
-pushd cpython >/dev/null
-unzip -o /tmp/timecraft-python.zip >/dev/null
-popd > /dev/null
+curl https://timecraft.s3.amazonaws.com/python/${commit}/python.wasm > cpython/python.wasm
+curl https://timecraft.s3.amazonaws.com/python/${commit}/python311.zip > cpython/usr/local/lib/python311.zip
 
 echo "Python downloaded at:"
 find . -name 'python.wasm' -o -name 'python311.zip'

--- a/python/download.sh
+++ b/python/download.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 if [ -z "$1" ]; then
     >&2 echo -e "$0 downloads pre-built WebAssembly python from s3.\nProvide timecraft git sha to download."
@@ -13,12 +13,10 @@ python_wasm_out="cpython/python.wasm"
 python_zip_out="cpython/usr/local/lib/python311.zip"
 
 mkdir -p cpython/usr/local/lib/
-curl https://timecraft.s3.amazonaws.com/python/${commit}/python.wasm > ${python_wasm_out}
-curl https://timecraft.s3.amazonaws.com/python/${commit}/python311.zip > ${python_zip_out}
+curl --fail-with-body https://timecraft.s3.amazonaws.com/python/${commit}/python.wasm > ${python_wasm_out}
+curl --fail-with-body https://timecraft.s3.amazonaws.com/python/${commit}/python311.zip > ${python_zip_out}
 
 echo "Python downloaded at:"
 echo ${python_wasm_out}
-cat ${python_wasm_out}
-
 echo ${python_zip_out}
-od -t x1 -N 8 ${python_zip_out}
+

--- a/python/download.sh
+++ b/python/download.sh
@@ -9,6 +9,7 @@ fi
 
 commit=$1
 
+mkdir -p cpython/usr/local/lib/
 curl https://timecraft.s3.amazonaws.com/python/${commit}/python.wasm > cpython/python.wasm
 curl https://timecraft.s3.amazonaws.com/python/${commit}/python311.zip > cpython/usr/local/lib/python311.zip
 

--- a/python/download.sh
+++ b/python/download.sh
@@ -9,9 +9,15 @@ fi
 
 commit=$1
 
+python_wasm_out="cpython/python.wasm"
+python_zip_out="cpython/usr/local/lib/python311.zip"
+
 mkdir -p cpython/usr/local/lib/
-curl https://timecraft.s3.amazonaws.com/python/${commit}/python.wasm > cpython/python.wasm
-curl https://timecraft.s3.amazonaws.com/python/${commit}/python311.zip > cpython/usr/local/lib/python311.zip
+curl https://timecraft.s3.amazonaws.com/python/${commit}/python.wasm > ${python_wasm_out}
+curl https://timecraft.s3.amazonaws.com/python/${commit}/python311.zip > ${python_zip_out}
 
 echo "Python downloaded at:"
-find . -name 'python.wasm' -o -name 'python311.zip'
+echo ${python_wasm_out}
+od -t x1 -N 8 ${python_wasm_out}
+echo ${python_zip_out}
+od -t x1 -N 8 ${python_zip_out}

--- a/python/download.sh
+++ b/python/download.sh
@@ -18,6 +18,7 @@ curl https://timecraft.s3.amazonaws.com/python/${commit}/python311.zip > ${pytho
 
 echo "Python downloaded at:"
 echo ${python_wasm_out}
-od -t x1 -N 8 ${python_wasm_out}
+cat ${python_wasm_out}
+
 echo ${python_zip_out}
 od -t x1 -N 8 ${python_zip_out}


### PR DESCRIPTION
Store python.wasm and python311.zip to S3 to allow easy retrieval by users.

On CI, the python build only occurs when a change has been made to `/python/*`. If a change was made, the python artifacts are rebuilt and published to S3.
The full test suite always runs. If a change to `/python` was made in the commit, it rebuilds the python artifacts. If not, it downloads the pre-built binaries of the last commit that did.