### PR TITLE
python: publish SDK to PyPi

### DIFF
--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,2 +1,3 @@
 build
+dist
 src/timecraft.egg-info

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -1,0 +1,20 @@
+# https://realpython.com/pypi-publish-python-package/#publish-your-package-to-pypi
+
+PYTHON ?= python3
+
+dist: deps
+	$(PYTHON) -m build
+
+test-upload: deps
+	$(PYTHON) -m twine upload -r testpypi dist/*
+
+upload: deps
+	$(PYTHON) -m twine upload dist/*
+
+.PHONY: deps
+deps:
+	$(PYTHON) -m pip install build twine
+
+.PHONY: clean
+clean:
+	rm -rf build dist src/timecraft.egg-info

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,1 @@
+The Python SDK for https://github.com/stealthrocket/timecraft


### PR DESCRIPTION
This PR adds a Makefile to help publish the Python SDK to PyPi.