### PR TITLE
go: non-blocking name resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/klauspost/compress v1.16.6
 	github.com/planetscale/vtprotobuf v0.4.0
-	github.com/stealthrocket/net v0.2.0
+	github.com/stealthrocket/net v0.2.1
 	github.com/stealthrocket/wasi-go v0.6.19
 	github.com/stealthrocket/wazergo v0.19.1
 	github.com/stealthrocket/wzprof v0.1.5

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/klauspost/compress v1.16.6
 	github.com/planetscale/vtprotobuf v0.4.0
-	github.com/stealthrocket/net v0.1.11
+	github.com/stealthrocket/net v0.2.0
 	github.com/stealthrocket/wasi-go v0.6.19
 	github.com/stealthrocket/wazergo v0.19.1
 	github.com/stealthrocket/wzprof v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/klauspost/compress v1.16.6/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQs
 github.com/planetscale/vtprotobuf v0.4.0 h1:NEI+g4woRaAZgeZ3sAvbtyvMBRjIv5kE7EWYQ8m4JwY=
 github.com/planetscale/vtprotobuf v0.4.0/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0PbwYYpP5P5VhTks=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stealthrocket/net v0.2.0 h1:V9ZHEGTDTdSdbnUBvXbkPKhuuPGP/xT75EmS8ODVKGM=
-github.com/stealthrocket/net v0.2.0/go.mod h1:VvoFod9pYC9mo+bEg2NQB/D+KVOjxfhZjZ5zyvozq7M=
+github.com/stealthrocket/net v0.2.1 h1:PehPGAAjuV46zaeHGlNgakFV7QDGUAREMcEQsZQ8NLo=
+github.com/stealthrocket/net v0.2.1/go.mod h1:VvoFod9pYC9mo+bEg2NQB/D+KVOjxfhZjZ5zyvozq7M=
 github.com/stealthrocket/wasi-go v0.6.19 h1:LrDbWyINP5faLicMTqglD2SniHtCmdajHpLgk4KeLDw=
 github.com/stealthrocket/wasi-go v0.6.19/go.mod h1:PJ5oVs2E1ciOJnsTnav4nvTtEcJ4D1jUZAewS9pzuZg=
 github.com/stealthrocket/wazergo v0.19.1 h1:BPrITETPgSFwiytwmToO0MbUC/+RGC39JScz1JmmG6c=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/klauspost/compress v1.16.6/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQs
 github.com/planetscale/vtprotobuf v0.4.0 h1:NEI+g4woRaAZgeZ3sAvbtyvMBRjIv5kE7EWYQ8m4JwY=
 github.com/planetscale/vtprotobuf v0.4.0/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0PbwYYpP5P5VhTks=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stealthrocket/net v0.1.11 h1:JPItm/qbkwtXwsc86k7Vb73yReMp+5yjAg84VG/BqoQ=
-github.com/stealthrocket/net v0.1.11/go.mod h1:VvoFod9pYC9mo+bEg2NQB/D+KVOjxfhZjZ5zyvozq7M=
+github.com/stealthrocket/net v0.2.0 h1:V9ZHEGTDTdSdbnUBvXbkPKhuuPGP/xT75EmS8ODVKGM=
+github.com/stealthrocket/net v0.2.0/go.mod h1:VvoFod9pYC9mo+bEg2NQB/D+KVOjxfhZjZ5zyvozq7M=
 github.com/stealthrocket/wasi-go v0.6.19 h1:LrDbWyINP5faLicMTqglD2SniHtCmdajHpLgk4KeLDw=
 github.com/stealthrocket/wasi-go v0.6.19/go.mod h1:PJ5oVs2E1ciOJnsTnav4nvTtEcJ4D1jUZAewS9pzuZg=
 github.com/stealthrocket/wazergo v0.19.1 h1:BPrITETPgSFwiytwmToO0MbUC/+RGC39JScz1JmmG6c=


### PR DESCRIPTION
This PR pulls in https://github.com/stealthrocket/net/pull/16, ensuring that name resolution in Go (and now _all_ I/O) is non-blocking.