### PR TITLE
test: don't pollute system-wide python packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,9 @@ testdata: $(testdata.go.wasm)
 %.wasm: %.go go.mod $(timecraft.sdk.src.go)
 	GOARCH=wasm GOOS=wasip1 $(GO) build -o $@ $<
 
-wasi-testsuite: timecraft testdata/wasi-testsuite
-	python3 -m pip install -r testdata/wasi-testsuite/test-runner/requirements.txt
-	python3 testdata/wasi-testsuite/test-runner/wasi_test_runner.py \
+wasi-testsuite: timecraft testdata/wasi-testsuite $(VIRTUALENV)/bin/activate
+	source $(VIRTUALENV)/bin/activate; pip install -r testdata/wasi-testsuite/test-runner/requirements.txt
+	source $(VIRTUALENV)/bin/activate; python3 testdata/wasi-testsuite/test-runner/wasi_test_runner.py \
 		-t testdata/wasi-testsuite/tests/assemblyscript/testsuite \
 		   testdata/wasi-testsuite/tests/c/testsuite \
 		   testdata/wasi-testsuite/tests/rust/testsuite \


### PR DESCRIPTION
wasi-testsuite dependencies are now installed into the test virtualenv.

Previously on Linux (Ubuntu 23.04) I was getting the following error:

```
 $ make wasi-testsuite
git submodule update --init --recursive -- testdata/wasi-testsuite
python3 -m pip install -r testdata/wasi-testsuite/test-runner/requirements.txt
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
make: *** [Makefile:98: wasi-testsuite] Error 1
```