### PR TITLE
profile: use profiling.Prepare

### DIFF
--- a/profile.go
+++ b/profile.go
@@ -141,7 +141,18 @@ func profile(ctx context.Context, args []string) error {
 		),
 	)
 
-	if err := replay.ReplayRecords(ctx, moduleCode, records); err != nil {
+	compiledModule, err := runtime.CompileModule(ctx, moduleCode)
+	if err != nil {
+		return err
+	}
+	defer compiledModule.Close(ctx)
+
+	err = p.Prepare(compiledModule)
+	if err != nil {
+		return err
+	}
+
+	if err := replay.ReplayRecordsModule(ctx, compiledModule, records); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
By not calling `profiling.Prepare` on the compiled module, timecraft would skip the symbolization selection, making wzprof fallback on the basic wasm name mapping.

Example with `testdata/go/htls.wasm`.

Before:

<img width="405" alt="Screenshot 2023-07-04 at 18 38 42" src="https://github.com/stealthrocket/timecraft/assets/172804/933913b5-6b38-4584-8b7c-33b023455bb5">

After:

<img width="309" alt="Screenshot 2023-07-04 at 18 38 33" src="https://github.com/stealthrocket/timecraft/assets/172804/7bb13bc2-06fb-443f-9167-f846d7c3491c">


