### PR TITLE
sandbox: fix poll timeout and allow resizing socket buffers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/klauspost/compress v1.16.6
 	github.com/planetscale/vtprotobuf v0.4.0
 	github.com/stealthrocket/net v0.2.1
-	github.com/stealthrocket/wasi-go v0.6.20
+	github.com/stealthrocket/wasi-go v0.7.2
 	github.com/stealthrocket/wazergo v0.19.1
 	github.com/stealthrocket/wzprof v0.1.5
 	github.com/tetratelabs/wazero v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/planetscale/vtprotobuf v0.4.0/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0P
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stealthrocket/net v0.2.1 h1:PehPGAAjuV46zaeHGlNgakFV7QDGUAREMcEQsZQ8NLo=
 github.com/stealthrocket/net v0.2.1/go.mod h1:VvoFod9pYC9mo+bEg2NQB/D+KVOjxfhZjZ5zyvozq7M=
-github.com/stealthrocket/wasi-go v0.6.20 h1:15j4vhbB3kmuTs14e91cGSivpmh+s6PHZkLQSx3Namc=
-github.com/stealthrocket/wasi-go v0.6.20/go.mod h1:PJ5oVs2E1ciOJnsTnav4nvTtEcJ4D1jUZAewS9pzuZg=
+github.com/stealthrocket/wasi-go v0.7.2 h1:7QIYqI5oLciiImKov3JhSbZjg5su7uKzxrCfzPxrNKg=
+github.com/stealthrocket/wasi-go v0.7.2/go.mod h1:PJ5oVs2E1ciOJnsTnav4nvTtEcJ4D1jUZAewS9pzuZg=
 github.com/stealthrocket/wazergo v0.19.1 h1:BPrITETPgSFwiytwmToO0MbUC/+RGC39JScz1JmmG6c=
 github.com/stealthrocket/wazergo v0.19.1/go.mod h1:riI0hxw4ndZA5e6z7PesHg2BtTftcZaMxRcoiGGipTs=
 github.com/stealthrocket/wzprof v0.1.5 h1:abEwQF9KtqV7UQ0hWk7431vul9/FxOg1eRCqwEKo9/4=

--- a/internal/sandbox/buffer.go
+++ b/internal/sandbox/buffer.go
@@ -69,8 +69,12 @@ func (rb *ringbuf[T]) append(values ...T) {
 
 func (rb *ringbuf[T]) pack() {
 	if rb.off > 0 {
-		n := copy(rb.buf, rb.buf[rb.off:rb.end])
+		n := copy(rb.buf, rb.values())
 		rb.end = int32(n)
 		rb.off = 0
 	}
+}
+
+func (rb *ringbuf[T]) values() []T {
+	return rb.buf[rb.off:rb.end]
 }

--- a/internal/sandbox/conn.go
+++ b/internal/sandbox/conn.go
@@ -355,7 +355,7 @@ func (c *packetConn[T]) writeTo(b []byte, addr T) (int, error) {
 			return len(b), nil
 		}
 		sock.synchronize(func() {
-			sock.allocateBuffersIfNil()
+			sock.resizeBuffersIfNeeded()
 			sbuf = sock.rbuf
 			sev = &sock.rbuf.wev
 		})
@@ -591,7 +591,7 @@ func (s *socket[T]) startPacketTunnel(ctx context.Context, conn net.PacketConn) 
 
 	errs := make(chan wasi.Errno, 2)
 	s.errs = errs
-	s.allocateBuffersIfNil()
+	s.resizeBuffersIfNeeded()
 
 	rbufsize := s.rbuf.size()
 	wbufsize := s.wbuf.size()
@@ -614,7 +614,7 @@ func (s *socket[T]) startPacketTunnelTo(ctx context.Context, conn net.Conn) {
 
 	errs := make(chan wasi.Errno, 2)
 	s.errs = errs
-	s.allocateBuffersIfNil()
+	s.resizeBuffersIfNeeded()
 
 	rbufsize := s.rbuf.size()
 	wbufsize := s.wbuf.size()

--- a/internal/sandbox/network.go
+++ b/internal/sandbox/network.go
@@ -265,7 +265,7 @@ func listen[N network[T], T sockaddr](s *System, n N, addr netaddr[T]) (net.List
 
 func listenPacket[N network[T], T sockaddr](s *System, n N, addr netaddr[T]) (net.PacketConn, error) {
 	socket := newSocket[T](n, datagram, addr.protocol, s.lock, s.poll)
-	socket.allocateBuffersIfNil()
+	socket.resizeBuffersIfNeeded()
 
 	if errno := n.bind(addr.sockaddr, socket); errno != wasi.ESUCCESS {
 		netAddr := addr.netAddr()

--- a/internal/sandbox/system.go
+++ b/internal/sandbox/system.go
@@ -774,11 +774,16 @@ func (s *System) pollOneOffScatter(subscriptions []wasi.Subscription, events []w
 				numEvents++
 				continue
 			}
+			duration := time.Duration(clock.Timeout)
+			if clock.Precision > 0 {
+				duration += time.Duration(clock.Precision)
+				duration -= 1
+			}
 			if (clock.Flags & wasi.Abstime) != 0 {
-				deadline := epoch.Add(time.Duration(clock.Timeout + clock.Precision))
+				deadline := epoch.Add(duration)
 				setTimeout(i, deadline.Sub(now))
 			} else {
-				setTimeout(i, time.Duration(clock.Timeout+clock.Precision))
+				setTimeout(i, duration)
 			}
 
 		case wasi.FDReadEvent, wasi.FDWriteEvent:


### PR DESCRIPTION
Follow up to https://github.com/stealthrocket/wasi-go/pull/77, this PR updates wasi-go and fixes the sandbox socket layer to pass the latest tests we added.

To address an issue with datagram sockets not triggering write events when created, I modified the creation of datagram sockets to always allocate the socket buffers, and also allowed socket buffers to be resized after a socket was used.

Please take a look and let me know if something should be changed.