### PR TITLE
run: add --chaotic mode

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"errors"
+	"math"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -45,6 +46,13 @@ func NotEqual[T comparable](t testing.TB, got, want T) {
 	if got == want {
 		t.Helper()
 		t.Fatalf("%T value must not be equal\nwant != %+v\ngot   = %+v", want, want, got)
+	}
+}
+
+func FloatEqual[T ~float32 | ~float64](t testing.TB, got, want, epsilon T) {
+	if math.Abs(float64(got-want)) > float64(epsilon) {
+		t.Helper()
+		t.Fatalf("%T value must be equal\nwant    = %+v\ngot     = %+v\nepsilon = %v\n", want, want, got, epsilon)
 	}
 }
 

--- a/internal/chaos/chaos.go
+++ b/internal/chaos/chaos.go
@@ -1,0 +1,311 @@
+package chaos
+
+import (
+	"context"
+	"math"
+	"math/rand"
+
+	"github.com/stealthrocket/wasi-go"
+)
+
+const (
+	maxChance = 1024 * 1024 * 1024
+)
+
+type Rule struct {
+	chance int64 // [0;maxChance]
+	system wasi.System
+}
+
+// Chance is a constructor for values of type Rule, mapping a system to a
+// probably of it being picked when methods are invoked.
+func Chance(chance float64, system wasi.System) Rule {
+	if chance < 0 || chance > 1 {
+		panic("invalid chance of chaos system rule is not in the range [0;1]")
+	}
+	return Rule{
+		chance: int64(math.Round(chance * maxChance)),
+		system: system,
+	}
+}
+
+// New constructs a new chaos system. The given random source is used for all
+// random number generation. The base system is the fallback when a probability
+// of method invocation did not match any of the rules. The list of rules pairs
+// a probability of being selected when a method of the system is invoked to the
+// system to delegate the invocation to. The systems set on rules are expected
+// to be instances of wrappers created by functions of this package to perform
+// fault injection.
+func New(prng rand.Source, base wasi.System, rules ...Rule) wasi.System {
+	s := &system{
+		prng:    prng,
+		base:    base,
+		chances: make([]int64, len(rules)),
+		systems: make([]wasi.System, len(rules)),
+	}
+	cumulativeChance := int64(0)
+	for i, rule := range rules {
+		cumulativeChance += rule.chance
+		s.chances[i] = cumulativeChance
+		s.systems[i] = rule.system
+		if cumulativeChance < 0 || cumulativeChance > maxChance {
+			panic("cumulative chance of chaos system rules is greater than 1")
+		}
+	}
+	return s
+}
+
+type system struct {
+	prng    rand.Source
+	base    wasi.System
+	chances []int64
+	systems []wasi.System
+}
+
+func (s *system) system() wasi.System {
+	probability := s.prng.Int63() & (maxChance - 1)
+	for i, chance := range s.chances {
+		if chance > probability {
+			return s.systems[i]
+		}
+	}
+	return s.base
+}
+
+func (s *system) ArgsSizesGet(ctx context.Context) (int, int, wasi.Errno) {
+	return s.system().ArgsSizesGet(ctx)
+}
+
+func (s *system) ArgsGet(ctx context.Context) ([]string, wasi.Errno) {
+	return s.system().ArgsGet(ctx)
+}
+
+func (s *system) EnvironSizesGet(ctx context.Context) (int, int, wasi.Errno) {
+	return s.system().EnvironSizesGet(ctx)
+}
+
+func (s *system) EnvironGet(ctx context.Context) ([]string, wasi.Errno) {
+	return s.system().EnvironGet(ctx)
+}
+
+func (s *system) ClockResGet(ctx context.Context, id wasi.ClockID) (wasi.Timestamp, wasi.Errno) {
+	return s.system().ClockResGet(ctx, id)
+}
+
+func (s *system) ClockTimeGet(ctx context.Context, id wasi.ClockID, precision wasi.Timestamp) (wasi.Timestamp, wasi.Errno) {
+	return s.system().ClockTimeGet(ctx, id, precision)
+}
+
+func (s *system) FDAdvise(ctx context.Context, fd wasi.FD, offset, length wasi.FileSize, advice wasi.Advice) wasi.Errno {
+	return s.system().FDAdvise(ctx, fd, offset, length, advice)
+}
+
+func (s *system) FDAllocate(ctx context.Context, fd wasi.FD, offset, length wasi.FileSize) wasi.Errno {
+	return s.system().FDAllocate(ctx, fd, offset, length)
+}
+
+func (s *system) FDClose(ctx context.Context, fd wasi.FD) wasi.Errno {
+	return s.system().FDClose(ctx, fd)
+}
+
+func (s *system) FDDataSync(ctx context.Context, fd wasi.FD) wasi.Errno {
+	return s.system().FDDataSync(ctx, fd)
+}
+
+func (s *system) FDStatGet(ctx context.Context, fd wasi.FD) (wasi.FDStat, wasi.Errno) {
+	return s.system().FDStatGet(ctx, fd)
+}
+
+func (s *system) FDStatSetFlags(ctx context.Context, fd wasi.FD, flags wasi.FDFlags) wasi.Errno {
+	return s.system().FDStatSetFlags(ctx, fd, flags)
+}
+
+func (s *system) FDStatSetRights(ctx context.Context, fd wasi.FD, rightsBase, rightsInheriting wasi.Rights) wasi.Errno {
+	return s.system().FDStatSetRights(ctx, fd, rightsBase, rightsInheriting)
+}
+
+func (s *system) FDFileStatGet(ctx context.Context, fd wasi.FD) (wasi.FileStat, wasi.Errno) {
+	return s.system().FDFileStatGet(ctx, fd)
+}
+
+func (s *system) FDFileStatSetSize(ctx context.Context, fd wasi.FD, size wasi.FileSize) wasi.Errno {
+	return s.system().FDFileStatSetSize(ctx, fd, size)
+}
+
+func (s *system) FDFileStatSetTimes(ctx context.Context, fd wasi.FD, accessTime, modifyTime wasi.Timestamp, flags wasi.FSTFlags) wasi.Errno {
+	return s.system().FDFileStatSetTimes(ctx, fd, accessTime, modifyTime, flags)
+}
+
+func (s *system) FDPread(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
+	return s.system().FDPread(ctx, fd, iovecs, offset)
+}
+
+func (s *system) FDPreStatGet(ctx context.Context, fd wasi.FD) (wasi.PreStat, wasi.Errno) {
+	return s.system().FDPreStatGet(ctx, fd)
+}
+
+func (s *system) FDPreStatDirName(ctx context.Context, fd wasi.FD) (string, wasi.Errno) {
+	return s.system().FDPreStatDirName(ctx, fd)
+}
+
+func (s *system) FDPwrite(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
+	return s.system().FDPwrite(ctx, fd, iovecs, offset)
+}
+
+func (s *system) FDRead(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec) (wasi.Size, wasi.Errno) {
+	return s.system().FDRead(ctx, fd, iovecs)
+}
+
+func (s *system) FDReadDir(ctx context.Context, fd wasi.FD, entries []wasi.DirEntry, cookie wasi.DirCookie, bufferSizeBytes int) (int, wasi.Errno) {
+	return s.system().FDReadDir(ctx, fd, entries, cookie, bufferSizeBytes)
+}
+
+func (s *system) FDRenumber(ctx context.Context, from, to wasi.FD) wasi.Errno {
+	return s.system().FDRenumber(ctx, from, to)
+}
+
+func (s *system) FDSeek(ctx context.Context, fd wasi.FD, offset wasi.FileDelta, whence wasi.Whence) (wasi.FileSize, wasi.Errno) {
+	return s.system().FDSeek(ctx, fd, offset, whence)
+}
+
+func (s *system) FDSync(ctx context.Context, fd wasi.FD) wasi.Errno {
+	return s.system().FDSync(ctx, fd)
+}
+
+func (s *system) FDTell(ctx context.Context, fd wasi.FD) (wasi.FileSize, wasi.Errno) {
+	return s.system().FDTell(ctx, fd)
+}
+
+func (s *system) FDWrite(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec) (wasi.Size, wasi.Errno) {
+	return s.system().FDWrite(ctx, fd, iovecs)
+}
+
+func (s *system) PathCreateDirectory(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
+	return s.system().PathCreateDirectory(ctx, fd, path)
+}
+
+func (s *system) PathFileStatGet(ctx context.Context, fd wasi.FD, lookupFlags wasi.LookupFlags, path string) (wasi.FileStat, wasi.Errno) {
+	return s.system().PathFileStatGet(ctx, fd, lookupFlags, path)
+}
+
+func (s *system) PathFileStatSetTimes(ctx context.Context, fd wasi.FD, lookupFlags wasi.LookupFlags, path string, accessTime, modifyTime wasi.Timestamp, flags wasi.FSTFlags) wasi.Errno {
+	return s.system().PathFileStatSetTimes(ctx, fd, lookupFlags, path, accessTime, modifyTime, flags)
+}
+
+func (s *system) PathLink(ctx context.Context, oldFD wasi.FD, oldFlags wasi.LookupFlags, oldPath string, newFD wasi.FD, newPath string) wasi.Errno {
+	return s.system().PathLink(ctx, oldFD, oldFlags, oldPath, newFD, newPath)
+}
+
+func (s *system) PathOpen(ctx context.Context, fd wasi.FD, dirFlags wasi.LookupFlags, path string, openFlags wasi.OpenFlags, rightsBase, rightsInheriting wasi.Rights, fdFlags wasi.FDFlags) (wasi.FD, wasi.Errno) {
+	return s.system().PathOpen(ctx, fd, dirFlags, path, openFlags, rightsBase, rightsInheriting, fdFlags)
+}
+
+func (s *system) PathReadLink(ctx context.Context, fd wasi.FD, path string, buffer []byte) (int, wasi.Errno) {
+	return s.system().PathReadLink(ctx, fd, path, buffer)
+}
+
+func (s *system) PathRemoveDirectory(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
+	return s.system().PathRemoveDirectory(ctx, fd, path)
+}
+
+func (s *system) PathRename(ctx context.Context, fd wasi.FD, oldPath string, newFD wasi.FD, newPath string) wasi.Errno {
+	return s.system().PathRename(ctx, fd, oldPath, newFD, newPath)
+}
+
+func (s *system) PathSymlink(ctx context.Context, oldPath string, fd wasi.FD, newPath string) wasi.Errno {
+	return s.system().PathSymlink(ctx, oldPath, fd, newPath)
+}
+
+func (s *system) PathUnlinkFile(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
+	return s.system().PathUnlinkFile(ctx, fd, path)
+}
+
+func (s *system) PollOneOff(ctx context.Context, subscriptions []wasi.Subscription, events []wasi.Event) (int, wasi.Errno) {
+	// We don't generate an error from PollOneOff itself because it usually
+	// results in crashing the application runtime. Instead, we injected errors
+	// on the collected events.
+	return s.system().PollOneOff(ctx, subscriptions, events)
+}
+
+func (s *system) ProcExit(ctx context.Context, exitCode wasi.ExitCode) wasi.Errno {
+	return s.system().ProcExit(ctx, exitCode)
+}
+
+func (s *system) ProcRaise(ctx context.Context, signal wasi.Signal) wasi.Errno {
+	return s.system().ProcRaise(ctx, signal)
+}
+
+func (s *system) SchedYield(ctx context.Context) wasi.Errno {
+	return s.system().SchedYield(ctx)
+}
+
+func (s *system) RandomGet(ctx context.Context, b []byte) wasi.Errno {
+	return s.system().RandomGet(ctx, b)
+}
+
+func (s *system) SockAccept(ctx context.Context, fd wasi.FD, flags wasi.FDFlags) (wasi.FD, wasi.SocketAddress, wasi.SocketAddress, wasi.Errno) {
+	return s.system().SockAccept(ctx, fd, flags)
+}
+
+func (s *system) SockShutdown(ctx context.Context, fd wasi.FD, flags wasi.SDFlags) wasi.Errno {
+	return s.system().SockShutdown(ctx, fd, flags)
+}
+
+func (s *system) SockRecv(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, iflags wasi.RIFlags) (wasi.Size, wasi.ROFlags, wasi.Errno) {
+	return s.system().SockRecv(ctx, fd, iovecs, iflags)
+}
+
+func (s *system) SockSend(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, iflags wasi.SIFlags) (wasi.Size, wasi.Errno) {
+	return s.system().SockSend(ctx, fd, iovecs, iflags)
+}
+
+func (s *system) SockOpen(ctx context.Context, pf wasi.ProtocolFamily, socketType wasi.SocketType, protocol wasi.Protocol, rightsBase, rightsInheriting wasi.Rights) (wasi.FD, wasi.Errno) {
+	return s.system().SockOpen(ctx, pf, socketType, protocol, rightsBase, rightsInheriting)
+}
+
+func (s *system) SockBind(ctx context.Context, fd wasi.FD, addr wasi.SocketAddress) (wasi.SocketAddress, wasi.Errno) {
+	return s.system().SockBind(ctx, fd, addr)
+}
+
+func (s *system) SockConnect(ctx context.Context, fd wasi.FD, peer wasi.SocketAddress) (wasi.SocketAddress, wasi.Errno) {
+	return s.system().SockConnect(ctx, fd, peer)
+}
+
+func (s *system) SockListen(ctx context.Context, fd wasi.FD, backlog int) wasi.Errno {
+	return s.system().SockListen(ctx, fd, backlog)
+}
+
+func (s *system) SockSendTo(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, iflags wasi.SIFlags, addr wasi.SocketAddress) (wasi.Size, wasi.Errno) {
+	return s.system().SockSendTo(ctx, fd, iovecs, iflags, addr)
+}
+
+func (s *system) SockRecvFrom(ctx context.Context, fd wasi.FD, iovecs []wasi.IOVec, iflags wasi.RIFlags) (wasi.Size, wasi.ROFlags, wasi.SocketAddress, wasi.Errno) {
+	return s.system().SockRecvFrom(ctx, fd, iovecs, iflags)
+}
+
+func (s *system) SockGetOpt(ctx context.Context, fd wasi.FD, option wasi.SocketOption) (wasi.SocketOptionValue, wasi.Errno) {
+	return s.system().SockGetOpt(ctx, fd, option)
+}
+
+func (s *system) SockSetOpt(ctx context.Context, fd wasi.FD, option wasi.SocketOption, value wasi.SocketOptionValue) wasi.Errno {
+	return s.system().SockSetOpt(ctx, fd, option, value)
+}
+
+func (s *system) SockLocalAddress(ctx context.Context, fd wasi.FD) (wasi.SocketAddress, wasi.Errno) {
+	return s.system().SockLocalAddress(ctx, fd)
+}
+
+func (s *system) SockRemoteAddress(ctx context.Context, fd wasi.FD) (wasi.SocketAddress, wasi.Errno) {
+	return s.system().SockRemoteAddress(ctx, fd)
+}
+
+func (s *system) SockAddressInfo(ctx context.Context, name, service string, hints wasi.AddressInfo, results []wasi.AddressInfo) (int, wasi.Errno) {
+	return s.system().SockAddressInfo(ctx, name, service, hints, results)
+}
+
+func (s *system) Close(ctx context.Context) error {
+	for _, system := range s.systems {
+		_ = system.Close(ctx)
+	}
+	return s.base.Close(ctx)
+}

--- a/internal/chaos/chaos_test.go
+++ b/internal/chaos/chaos_test.go
@@ -35,7 +35,8 @@ func TestRandomSystemSelection(t *testing.T) {
 		assert.Equal(t, errno, wasi.ESUCCESS)
 	}
 
-	assert.FloatEqual(t, float64(s1.yield)/N, 0.7, 0.01)
-	assert.FloatEqual(t, float64(s2.yield)/N, 0.1, 0.01)
-	assert.FloatEqual(t, float64(s3.yield)/N, 0.2, 0.01)
+	const epsilon = 0.01
+	assert.FloatEqual(t, float64(s1.yield)/N, 0.7, epsilon)
+	assert.FloatEqual(t, float64(s2.yield)/N, 0.1, epsilon)
+	assert.FloatEqual(t, float64(s3.yield)/N, 0.2, epsilon)
 }

--- a/internal/chaos/chaos_test.go
+++ b/internal/chaos/chaos_test.go
@@ -1,0 +1,41 @@
+package chaos_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/stealthrocket/timecraft/internal/assert"
+	"github.com/stealthrocket/timecraft/internal/chaos"
+	"github.com/stealthrocket/wasi-go"
+)
+
+type yieldSystem struct {
+	wasi.System
+	yield int
+}
+
+func (s *yieldSystem) SchedYield(ctx context.Context) wasi.Errno {
+	s.yield++
+	return wasi.ESUCCESS
+}
+
+func TestRandomSystemSelection(t *testing.T) {
+	s1 := new(yieldSystem)
+	s2 := new(yieldSystem)
+	s3 := new(yieldSystem)
+
+	prng := rand.NewSource(0)
+	sys := chaos.New(prng, s1, chaos.Chance(0.1, s2), chaos.Chance(0.2, s3))
+	ctx := context.Background()
+
+	const N = 1e6
+	for i := 0; i < N; i++ {
+		errno := sys.SchedYield(ctx)
+		assert.Equal(t, errno, wasi.ESUCCESS)
+	}
+
+	assert.FloatEqual(t, float64(s1.yield)/N, 0.7, 0.01)
+	assert.FloatEqual(t, float64(s2.yield)/N, 0.1, 0.01)
+	assert.FloatEqual(t, float64(s3.yield)/N, 0.2, 0.01)
+}

--- a/internal/chaos/chunk.go
+++ b/internal/chaos/chunk.go
@@ -1,0 +1,127 @@
+package chaos
+
+import (
+	"context"
+
+	"github.com/stealthrocket/wasi-go"
+)
+
+// Chunk wraps the base system to return one that chunks reads and writes to
+// only partially use the I/O vectors. The intent is to exercise paths that
+// handle successful but partial completion of I/O operations.
+//
+// This fault injector has a side effect of increasing latency of I/O operations
+// because it breaks down the buffering layers that are usually implemented in
+// applications, which may cause measurable slow downs if triggered too often.
+//
+// The filter does not apply to datagram sockets because truncating messages
+// may break network protocols such as DNS, and the intent of this wrapper is
+// not to inject irrecoverable errors.
+func Chunk(base wasi.System) wasi.System {
+	return &chunkSystem{System: base}
+}
+
+func canBeChunked(fileType wasi.FileType) bool {
+	return fileType != wasi.SocketDGramType
+}
+
+type chunkSystem struct {
+	wasi.System
+	iovs [1]wasi.IOVec
+}
+
+func (s *chunkSystem) chunk(fileType wasi.FileType, iovs []wasi.IOVec) []wasi.IOVec {
+	if canBeChunked(fileType) {
+		for _, iov := range iovs {
+			if len(iov) != 0 {
+				s.iovs[0] = iov[:1]
+				return s.iovs[:]
+			}
+		}
+	}
+	return iovs
+}
+
+func (s *chunkSystem) reset() {
+	s.iovs[0] = nil
+}
+
+func (s *chunkSystem) FDPread(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
+	f, errno := s.System.FDStatGet(ctx, fd)
+	if errno != wasi.ESUCCESS {
+		return ^wasi.Size(0), errno
+	}
+	iovs = s.chunk(f.FileType, iovs)
+	defer s.reset()
+	return s.System.FDPread(ctx, fd, iovs, offset)
+}
+
+func (s *chunkSystem) FDPwrite(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
+	f, errno := s.System.FDStatGet(ctx, fd)
+	if errno != wasi.ESUCCESS {
+		return ^wasi.Size(0), errno
+	}
+	iovs = s.chunk(f.FileType, iovs)
+	defer s.reset()
+	return s.System.FDPwrite(ctx, fd, iovs, offset)
+}
+
+func (s *chunkSystem) FDRead(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec) (wasi.Size, wasi.Errno) {
+	f, errno := s.System.FDStatGet(ctx, fd)
+	if errno != wasi.ESUCCESS {
+		return ^wasi.Size(0), errno
+	}
+	iovs = s.chunk(f.FileType, iovs)
+	defer s.reset()
+	return s.System.FDRead(ctx, fd, iovs)
+}
+
+func (s *chunkSystem) FDWrite(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec) (wasi.Size, wasi.Errno) {
+	f, errno := s.System.FDStatGet(ctx, fd)
+	if errno != wasi.ESUCCESS {
+		return ^wasi.Size(0), errno
+	}
+	iovs = s.chunk(f.FileType, iovs)
+	defer s.reset()
+	return s.System.FDWrite(ctx, fd, iovs)
+}
+
+func (s *chunkSystem) SockRecv(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, iflags wasi.RIFlags) (wasi.Size, wasi.ROFlags, wasi.Errno) {
+	f, errno := s.System.FDStatGet(ctx, fd)
+	if errno != wasi.ESUCCESS {
+		return ^wasi.Size(0), wasi.ROFlags(0), errno
+	}
+	iovs = s.chunk(f.FileType, iovs)
+	defer s.reset()
+	return s.System.SockRecv(ctx, fd, iovs, iflags)
+}
+
+func (s *chunkSystem) SockSend(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, iflags wasi.SIFlags) (wasi.Size, wasi.Errno) {
+	f, errno := s.System.FDStatGet(ctx, fd)
+	if errno != wasi.ESUCCESS {
+		return ^wasi.Size(0), errno
+	}
+	iovs = s.chunk(f.FileType, iovs)
+	defer s.reset()
+	return s.System.SockSend(ctx, fd, iovs, iflags)
+}
+
+func (s *chunkSystem) SockRecvFrom(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, iflags wasi.RIFlags) (wasi.Size, wasi.ROFlags, wasi.SocketAddress, wasi.Errno) {
+	f, errno := s.System.FDStatGet(ctx, fd)
+	if errno != wasi.ESUCCESS {
+		return ^wasi.Size(0), wasi.ROFlags(0), nil, errno
+	}
+	iovs = s.chunk(f.FileType, iovs)
+	defer s.reset()
+	return s.System.SockRecvFrom(ctx, fd, iovs, iflags)
+}
+
+func (s *chunkSystem) SockSendTo(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, iflags wasi.SIFlags, addr wasi.SocketAddress) (wasi.Size, wasi.Errno) {
+	f, errno := s.System.FDStatGet(ctx, fd)
+	if errno != wasi.ESUCCESS {
+		return ^wasi.Size(0), errno
+	}
+	iovs = s.chunk(f.FileType, iovs)
+	defer s.reset()
+	return s.System.SockSendTo(ctx, fd, iovs, iflags, addr)
+}

--- a/internal/chaos/error.go
+++ b/internal/chaos/error.go
@@ -1,0 +1,358 @@
+package chaos
+
+import (
+	"context"
+
+	"github.com/stealthrocket/wasi-go"
+)
+
+// Error wraps the base system to return one that errors on almost all method
+// calls.
+//
+// The error returned may vary depending on the method, most will return EIO,
+// ENOBUFS, or ECONNRESET.
+//
+// Invocations of methods always first call the corresponding method of the base
+// system to so that argument validation is performed before generating errors.
+// This is done so that we don't produce impossible errors such as EIO on an
+// invalid file descriptor number. Note that it means the program cannot assume
+// that an operation succeeded or failed when it gets an error from this system,
+// which is excellent to exercise recovery mechanisms after an error was
+// injected on a write operation.
+//
+// Errors are not injected in methods that are necessary for a minimal working
+// application such as reading arguments or exiting the program. Injecting
+// errors in those method calls would likely result in uninteresting conditions,
+// like the application not starting at all.
+func Error(base wasi.System) wasi.System {
+	return &errorSystem{base: base}
+}
+
+type errorSystem struct {
+	base wasi.System
+}
+
+func (s *errorSystem) ArgsSizesGet(ctx context.Context) (int, int, wasi.Errno) {
+	return s.base.ArgsSizesGet(ctx)
+}
+
+func (s *errorSystem) ArgsGet(ctx context.Context) ([]string, wasi.Errno) {
+	return s.base.ArgsGet(ctx)
+}
+
+func (s *errorSystem) EnvironSizesGet(ctx context.Context) (int, int, wasi.Errno) {
+	return s.base.EnvironSizesGet(ctx)
+}
+
+func (s *errorSystem) EnvironGet(ctx context.Context) ([]string, wasi.Errno) {
+	return s.base.EnvironGet(ctx)
+}
+
+func (s *errorSystem) ClockResGet(ctx context.Context, id wasi.ClockID) (wasi.Timestamp, wasi.Errno) {
+	return s.base.ClockResGet(ctx, id)
+}
+
+func (s *errorSystem) ClockTimeGet(ctx context.Context, id wasi.ClockID, precision wasi.Timestamp) (wasi.Timestamp, wasi.Errno) {
+	return s.base.ClockTimeGet(ctx, id, precision)
+}
+
+func (s *errorSystem) FDAdvise(ctx context.Context, fd wasi.FD, offset, length wasi.FileSize, advice wasi.Advice) wasi.Errno {
+	errno := s.base.FDAdvise(ctx, fd, offset, length, advice)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDAllocate(ctx context.Context, fd wasi.FD, offset, length wasi.FileSize) wasi.Errno {
+	errno := s.base.FDAllocate(ctx, fd, offset, length)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDClose(ctx context.Context, fd wasi.FD) wasi.Errno {
+	errno := s.base.FDClose(ctx, fd)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDDataSync(ctx context.Context, fd wasi.FD) wasi.Errno {
+	errno := s.base.FDDataSync(ctx, fd)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDStatGet(ctx context.Context, fd wasi.FD) (wasi.FDStat, wasi.Errno) {
+	_, errno := s.base.FDStatGet(ctx, fd)
+	return wasi.FDStat{}, replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDStatSetFlags(ctx context.Context, fd wasi.FD, flags wasi.FDFlags) wasi.Errno {
+	return s.base.FDStatSetFlags(ctx, fd, flags)
+}
+
+func (s *errorSystem) FDStatSetRights(ctx context.Context, fd wasi.FD, rightsBase, rightsInheriting wasi.Rights) wasi.Errno {
+	return s.base.FDStatSetRights(ctx, fd, rightsBase, rightsInheriting)
+}
+
+func (s *errorSystem) FDFileStatGet(ctx context.Context, fd wasi.FD) (wasi.FileStat, wasi.Errno) {
+	_, errno := s.base.FDFileStatGet(ctx, fd)
+	return wasi.FileStat{}, replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDFileStatSetSize(ctx context.Context, fd wasi.FD, size wasi.FileSize) wasi.Errno {
+	errno := s.base.FDFileStatSetSize(ctx, fd, size)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDFileStatSetTimes(ctx context.Context, fd wasi.FD, accessTime, modifyTime wasi.Timestamp, flags wasi.FSTFlags) wasi.Errno {
+	errno := s.base.FDFileStatSetTimes(ctx, fd, accessTime, modifyTime, flags)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDPread(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
+	_, errno := s.base.FDPread(ctx, fd, iovs, offset)
+	return ^wasi.Size(0), replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDPreStatGet(ctx context.Context, fd wasi.FD) (wasi.PreStat, wasi.Errno) {
+	_, errno := s.base.FDPreStatGet(ctx, fd)
+	return wasi.PreStat{}, replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDPreStatDirName(ctx context.Context, fd wasi.FD) (string, wasi.Errno) {
+	_, errno := s.base.FDPreStatDirName(ctx, fd)
+	return "", replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDPwrite(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, offset wasi.FileSize) (wasi.Size, wasi.Errno) {
+	_, errno := s.base.FDPwrite(ctx, fd, iovs, offset)
+	return ^wasi.Size(0), replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDRead(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec) (wasi.Size, wasi.Errno) {
+	_, errno := s.base.FDRead(ctx, fd, iovs)
+	return ^wasi.Size(0), replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDReadDir(ctx context.Context, fd wasi.FD, entries []wasi.DirEntry, cookie wasi.DirCookie, bufferSizeBytes int) (int, wasi.Errno) {
+	_, errno := s.base.FDReadDir(ctx, fd, entries, cookie, bufferSizeBytes)
+	return 0, replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDRenumber(ctx context.Context, from, to wasi.FD) wasi.Errno {
+	return s.base.FDRenumber(ctx, from, to)
+}
+
+func (s *errorSystem) FDSeek(ctx context.Context, fd wasi.FD, offset wasi.FileDelta, whence wasi.Whence) (wasi.FileSize, wasi.Errno) {
+	_, errno := s.base.FDSeek(ctx, fd, offset, whence)
+	return ^wasi.FileSize(0), replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDSync(ctx context.Context, fd wasi.FD) wasi.Errno {
+	errno := s.base.FDSync(ctx, fd)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDTell(ctx context.Context, fd wasi.FD) (wasi.FileSize, wasi.Errno) {
+	_, errno := s.base.FDTell(ctx, fd)
+	return ^wasi.FileSize(0), replaceWithEIO(errno)
+}
+
+func (s *errorSystem) FDWrite(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec) (wasi.Size, wasi.Errno) {
+	_, errno := s.base.FDWrite(ctx, fd, iovs)
+	return ^wasi.Size(0), replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PathCreateDirectory(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
+	errno := s.base.PathCreateDirectory(ctx, fd, path)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PathFileStatGet(ctx context.Context, fd wasi.FD, lookupFlags wasi.LookupFlags, path string) (wasi.FileStat, wasi.Errno) {
+	_, errno := s.base.PathFileStatGet(ctx, fd, lookupFlags, path)
+	return wasi.FileStat{}, replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PathFileStatSetTimes(ctx context.Context, fd wasi.FD, lookupFlags wasi.LookupFlags, path string, accessTime, modifyTime wasi.Timestamp, flags wasi.FSTFlags) wasi.Errno {
+	errno := s.base.PathFileStatSetTimes(ctx, fd, lookupFlags, path, accessTime, modifyTime, flags)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PathLink(ctx context.Context, oldFD wasi.FD, oldFlags wasi.LookupFlags, oldPath string, newFD wasi.FD, newPath string) wasi.Errno {
+	errno := s.base.PathLink(ctx, oldFD, oldFlags, oldPath, newFD, newPath)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PathOpen(ctx context.Context, fd wasi.FD, dirFlags wasi.LookupFlags, path string, openFlags wasi.OpenFlags, rightsBase, rightsInheriting wasi.Rights, fdFlags wasi.FDFlags) (wasi.FD, wasi.Errno) {
+	_, errno := s.base.PathOpen(ctx, fd, dirFlags, path, openFlags, rightsBase, rightsInheriting, fdFlags)
+	if errno == wasi.ESUCCESS {
+		s.base.FDClose(ctx, fd)
+		errno = wasi.EIO
+	}
+	return -1, errno
+}
+
+func (s *errorSystem) PathReadLink(ctx context.Context, fd wasi.FD, path string, buffer []byte) (int, wasi.Errno) {
+	_, errno := s.base.PathReadLink(ctx, fd, path, buffer)
+	return 0, replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PathRemoveDirectory(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
+	errno := s.base.PathRemoveDirectory(ctx, fd, path)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PathRename(ctx context.Context, fd wasi.FD, oldPath string, newFD wasi.FD, newPath string) wasi.Errno {
+	errno := s.base.PathRename(ctx, fd, oldPath, newFD, newPath)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PathSymlink(ctx context.Context, oldPath string, fd wasi.FD, newPath string) wasi.Errno {
+	errno := s.base.PathSymlink(ctx, oldPath, fd, newPath)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PathUnlinkFile(ctx context.Context, fd wasi.FD, path string) wasi.Errno {
+	errno := s.base.PathUnlinkFile(ctx, fd, path)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) PollOneOff(ctx context.Context, subscriptions []wasi.Subscription, events []wasi.Event) (int, wasi.Errno) {
+	// We don't generate an error from PollOneOff itself because it usually
+	// results in crashing the application runtime. Instead, we injected errors
+	// on the collected events.
+	n, errno := s.base.PollOneOff(ctx, subscriptions, events)
+	if n > 0 {
+		for i, e := range events[:n] {
+			switch e.EventType {
+			case wasi.FDReadEvent, wasi.FDWriteEvent:
+				events[i].Errno = replaceWithEIO(e.Errno)
+			}
+		}
+	}
+	return n, errno
+}
+
+func (s *errorSystem) ProcExit(ctx context.Context, exitCode wasi.ExitCode) wasi.Errno {
+	return s.base.ProcExit(ctx, exitCode)
+}
+
+func (s *errorSystem) ProcRaise(ctx context.Context, signal wasi.Signal) wasi.Errno {
+	return s.base.ProcRaise(ctx, signal)
+}
+
+func (s *errorSystem) SchedYield(ctx context.Context) wasi.Errno {
+	return s.base.SchedYield(ctx)
+}
+
+func (s *errorSystem) RandomGet(ctx context.Context, b []byte) wasi.Errno {
+	errno := s.base.RandomGet(ctx, b)
+	return replaceWithEIO(errno)
+}
+
+func (s *errorSystem) SockAccept(ctx context.Context, fd wasi.FD, flags wasi.FDFlags) (wasi.FD, wasi.SocketAddress, wasi.SocketAddress, wasi.Errno) {
+	newfd, peer, addr, errno := s.base.SockAccept(ctx, fd, flags)
+	if errno == wasi.ESUCCESS {
+		// We don't replace the error but instead shutdown the newly accepted
+		// socket to make it unusable. This will trigger different types of
+		// errors on recv/send even if the error system isn't invoked anymore
+		// when interacting with the socket.
+		_ = s.base.SockShutdown(ctx, newfd, wasi.ShutdownRD|wasi.ShutdownWR)
+	}
+	return newfd, peer, addr, errno
+}
+
+func (s *errorSystem) SockShutdown(ctx context.Context, fd wasi.FD, flags wasi.SDFlags) wasi.Errno {
+	return s.base.SockShutdown(ctx, fd, flags)
+}
+
+func (s *errorSystem) SockRecv(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, iflags wasi.RIFlags) (wasi.Size, wasi.ROFlags, wasi.Errno) {
+	_, _, errno := s.base.SockRecv(ctx, fd, iovs, iflags)
+	return ^wasi.Size(0), wasi.ROFlags(0), replaceWithETIMEDOUT(errno)
+}
+
+func (s *errorSystem) SockSend(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, iflags wasi.SIFlags) (wasi.Size, wasi.Errno) {
+	_, errno := s.base.SockSend(ctx, fd, iovs, iflags)
+	return ^wasi.Size(0), replaceWithETIMEDOUT(errno)
+}
+
+func (s *errorSystem) SockOpen(ctx context.Context, pf wasi.ProtocolFamily, socketType wasi.SocketType, protocol wasi.Protocol, rightsBase, rightsInheriting wasi.Rights) (wasi.FD, wasi.Errno) {
+	fd, errno := s.base.SockOpen(ctx, pf, socketType, protocol, rightsBase, rightsInheriting)
+	if errno == wasi.ESUCCESS {
+		s.base.FDClose(ctx, fd)
+		errno = wasi.ENOBUFS
+	}
+	return fd, errno
+}
+
+func (s *errorSystem) SockBind(ctx context.Context, fd wasi.FD, addr wasi.SocketAddress) (wasi.SocketAddress, wasi.Errno) {
+	return s.base.SockBind(ctx, fd, addr)
+}
+
+func (s *errorSystem) SockConnect(ctx context.Context, fd wasi.FD, peer wasi.SocketAddress) (wasi.SocketAddress, wasi.Errno) {
+	addr, errno := s.base.SockConnect(ctx, fd, peer)
+	switch errno {
+	case wasi.ESUCCESS, wasi.EINPROGRESS:
+		// Same reasoning as for accepted sockets, shutdown the socket so
+		// it becomes unusable, even if the connection was successfully
+		// initiated.
+		_ = s.base.SockShutdown(ctx, fd, wasi.ShutdownRD|wasi.ShutdownWR)
+	}
+	return addr, errno
+}
+
+func (s *errorSystem) SockListen(ctx context.Context, fd wasi.FD, backlog int) wasi.Errno {
+	return s.base.SockListen(ctx, fd, backlog)
+}
+
+func (s *errorSystem) SockRecvFrom(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, iflags wasi.RIFlags) (wasi.Size, wasi.ROFlags, wasi.SocketAddress, wasi.Errno) {
+	_, _, _, errno := s.base.SockRecvFrom(ctx, fd, iovs, iflags)
+	return ^wasi.Size(0), wasi.ROFlags(0), nil, replaceWithENOBUFS(errno)
+}
+
+func (s *errorSystem) SockSendTo(ctx context.Context, fd wasi.FD, iovs []wasi.IOVec, iflags wasi.SIFlags, addr wasi.SocketAddress) (wasi.Size, wasi.Errno) {
+	_, errno := s.base.SockSendTo(ctx, fd, iovs, iflags, addr)
+	return ^wasi.Size(0), replaceWithENOBUFS(errno)
+}
+
+func (s *errorSystem) SockGetOpt(ctx context.Context, fd wasi.FD, option wasi.SocketOption) (wasi.SocketOptionValue, wasi.Errno) {
+	_, errno := s.base.SockGetOpt(ctx, fd, option)
+	return nil, replaceWithENOBUFS(errno)
+}
+
+func (s *errorSystem) SockSetOpt(ctx context.Context, fd wasi.FD, option wasi.SocketOption, value wasi.SocketOptionValue) wasi.Errno {
+	return s.base.SockSetOpt(ctx, fd, option, value)
+}
+
+func (s *errorSystem) SockLocalAddress(ctx context.Context, fd wasi.FD) (wasi.SocketAddress, wasi.Errno) {
+	_, errno := s.base.SockLocalAddress(ctx, fd)
+	return nil, replaceWithENOBUFS(errno)
+}
+
+func (s *errorSystem) SockRemoteAddress(ctx context.Context, fd wasi.FD) (wasi.SocketAddress, wasi.Errno) {
+	_, errno := s.base.SockRemoteAddress(ctx, fd)
+	return nil, replaceWithENOBUFS(errno)
+}
+
+func (s *errorSystem) SockAddressInfo(ctx context.Context, name, service string, hints wasi.AddressInfo, results []wasi.AddressInfo) (int, wasi.Errno) {
+	_, errno := s.base.SockAddressInfo(ctx, name, service, hints, results)
+	return 0, replaceWithEIO(errno)
+}
+
+func (s *errorSystem) Close(ctx context.Context) error {
+	return s.base.Close(ctx)
+}
+
+func replaceWithEIO(errno wasi.Errno) wasi.Errno {
+	return replaceErrnoWith(errno, wasi.EIO)
+}
+
+func replaceWithENOBUFS(errno wasi.Errno) wasi.Errno {
+	return replaceErrnoWith(errno, wasi.ENOBUFS)
+}
+
+func replaceWithETIMEDOUT(errno wasi.Errno) wasi.Errno {
+	return replaceErrnoWith(errno, wasi.ETIMEDOUT)
+}
+
+func replaceErrnoWith(errno, replace wasi.Errno) wasi.Errno {
+	if errno == wasi.ESUCCESS {
+		errno = replace
+	}
+	return errno
+}

--- a/internal/chaos/random.go
+++ b/internal/chaos/random.go
@@ -1,0 +1,38 @@
+package chaos
+
+import (
+	"context"
+
+	"github.com/stealthrocket/wasi-go"
+)
+
+// LowEntropy constructs a system with a low entropy source for random data
+// generation. The seed data is used to generate random data that is not safe
+// for cryptographic use and will likely cause repeatitions in the pattern of
+// random data exposed to a guest program.
+func LowEntropy(base wasi.System) wasi.System {
+	return &randomSystem{System: base, off: -1}
+}
+
+type randomSystem struct {
+	wasi.System
+	off  int
+	seed [1024]byte
+}
+
+func (s *randomSystem) RandomGet(ctx context.Context, data []byte) wasi.Errno {
+	if s.off < 0 {
+		// Lazily initialize the seed data from the underlying system; this
+		// ensures that we won't produce random data if the system did not
+		// suport it.
+		if errno := s.System.RandomGet(ctx, s.seed[:]); errno != wasi.ESUCCESS {
+			return errno
+		}
+		s.off = 0
+	}
+	for len(data) > 0 {
+		data = data[copy(data, s.seed[s.off:]):]
+		s.off = (s.off + 1) % len(s.seed)
+	}
+	return wasi.ESUCCESS
+}

--- a/internal/chaos/time.go
+++ b/internal/chaos/time.go
@@ -1,0 +1,123 @@
+package chaos
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/stealthrocket/wasi-go"
+)
+
+const (
+	// Clocks will be reset roughly every minute; note that this is subject to
+	// fluctuations from the underlying system clocks that the system gets the
+	// current timestamps from.
+	driftResetDelay = wasi.Timestamp(time.Minute)
+)
+
+// ClockDrift wraps the base system to return one where the clock is drifting
+// by a random factor.
+func ClockDrift(base wasi.System) wasi.System {
+	return &clockDriftSystem{System: base}
+}
+
+type clockDriftSystem struct {
+	wasi.System
+	prng  *rand.Rand
+	drift float64
+	clock [4]clock
+	reset []clockSubscription
+}
+
+type clock struct {
+	epoch wasi.Timestamp
+	errno wasi.Errno
+}
+
+type clockSubscription struct {
+	i int
+	s wasi.Subscription
+}
+
+func (s *clockDriftSystem) ClockTimeGet(ctx context.Context, id wasi.ClockID, precision wasi.Timestamp) (wasi.Timestamp, wasi.Errno) {
+	t, errno := s.System.ClockTimeGet(ctx, wasi.Monotonic, 1)
+	if errno != wasi.ESUCCESS {
+		// We need the underlying system to support monotonic clocks to
+		// derive the drift on realtime clocks.
+		return t, errno
+	}
+
+	i := int(id)
+	if i < 0 || i >= len(s.clock) {
+		// We only support the 4 clocks defined in the WASI preview 1
+		// specification.
+		return 0, wasi.ENOSYS
+	}
+
+	// When the timestamp is before the next reset point of the clock,
+	// return the timestamp adjusted by the drift.
+	if m := &s.clock[wasi.Monotonic]; m.epoch != 0 && t < m.epoch+driftResetDelay {
+		d := float64(t-m.epoch) * s.drift
+		c := &s.clock[i]
+		return c.epoch + wasi.Timestamp(d), c.errno
+	}
+
+	// Lazily allocate the random number generator using the current
+	// timestmap as seed, this makes for a good-enough seed selection
+	// without having to explicitly expose configuration. This remains
+	// deterministic as long as the underlying system is.
+	if s.prng == nil {
+		s.prng = rand.New(rand.NewSource(int64(t)))
+	}
+	// Each time the clocks get reset we compute a new drift to emulate a
+	// clock skew correction not being completely accurate.
+	s.drift = 1.0 + ((0.2 * s.prng.Float64()) - 0.1)
+
+	for i := range s.clock {
+		epoch, errno := s.System.ClockTimeGet(ctx, wasi.ClockID(i), 1)
+		s.clock[i].epoch = epoch
+		s.clock[i].errno = errno
+	}
+
+	c := &s.clock[i]
+	return c.epoch, c.errno
+}
+
+func (s *clockDriftSystem) PollOneOff(ctx context.Context, subscriptions []wasi.Subscription, events []wasi.Event) (int, wasi.Errno) {
+	s.reset = s.reset[:0]
+
+	// Apply the reverse drift to absolute clock events found in the
+	// subscription array since the application may have miscalculated
+	// those.
+	for i, sub := range subscriptions {
+		if sub.EventType != wasi.ClockEvent {
+			continue
+		}
+		clockEvent := sub.GetClock()
+		if !clockEvent.Flags.Has(wasi.Abstime) {
+			continue
+		}
+		clockID := int(clockEvent.ID)
+		if clockID < 0 || clockID >= len(s.clock) {
+			continue
+		}
+		c := &s.clock[clockID]
+		if c.errno != wasi.ESUCCESS {
+			continue
+		}
+		d := float64(clockEvent.Timeout-c.epoch) * -s.drift
+		clockEvent.Timeout = c.epoch + wasi.Timestamp(d)
+		subscriptions[i] = wasi.MakeSubscriptionClock(sub.UserData, clockEvent)
+		s.reset = append(s.reset, clockSubscription{i, sub})
+	}
+
+	defer func() {
+		// Reset the timeouts we altered so the application does not know that
+		// we mutated the subscription array.
+		for _, reset := range s.reset {
+			subscriptions[reset.i] = reset.s
+		}
+	}()
+
+	return s.System.PollOneOff(ctx, subscriptions, events)
+}

--- a/internal/chaos/time_test.go
+++ b/internal/chaos/time_test.go
@@ -1,0 +1,66 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stealthrocket/timecraft/internal/assert"
+	"github.com/stealthrocket/timecraft/internal/chaos"
+	"github.com/stealthrocket/timecraft/internal/sandbox"
+	"github.com/stealthrocket/wasi-go"
+)
+
+func TestClockDrift(t *testing.T) {
+	epoch := time.Now()
+
+	currentTime := epoch
+	timeFunc := func() time.Time { return currentTime }
+
+	sys := chaos.ClockDrift(sandbox.New(sandbox.Time(timeFunc)))
+	ctx := context.Background()
+
+	timeline := make([]wasi.Timestamp, 120*1e3)
+
+	computeDrift := func(timestamp wasi.Timestamp) time.Duration {
+		drift := time.Duration(currentTime.Sub(time.Unix(0, int64(timestamp))))
+		if drift < 0 {
+			drift = -drift
+		}
+		return drift
+	}
+
+	for i := range timeline {
+		timestamp, errno := sys.ClockTimeGet(ctx, wasi.Realtime, 1)
+		assert.Equal(t, errno, wasi.ESUCCESS)
+
+		drift := computeDrift(timestamp)
+		if drift > currentTime.Sub(epoch) {
+			t.Fatalf("drift cannot be greater than total duration: drift=%s duration=%s", drift, currentTime.Sub(epoch))
+		}
+
+		timeline[i] = timestamp
+		currentTime = currentTime.Add(time.Millisecond)
+	}
+
+	drift := computeDrift(timeline[len(timeline)-1])
+	t.Logf("drift after %s = %s\n", currentTime.Sub(epoch), drift)
+}
+
+func BenchmarkClockDrift(b *testing.B) {
+	epoch := time.Now()
+
+	currentTime := epoch
+	timeFunc := func() time.Time { return currentTime }
+
+	sys := chaos.ClockDrift(sandbox.New(sandbox.Time(timeFunc)))
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		_, errno := sys.ClockTimeGet(ctx, wasi.Realtime, 1)
+		if errno != wasi.ESUCCESS {
+			b.Fatal(errno)
+		}
+		currentTime = currentTime.Add(time.Millisecond)
+	}
+}

--- a/internal/timecraft/process.go
+++ b/internal/timecraft/process.go
@@ -40,6 +40,7 @@ type ProcessManager struct {
 	registry      *timemachine.Registry
 	runtime       wazero.Runtime
 	serverFactory *ServerFactory
+	adapter       func(ProcessID, wasi.System) wasi.System
 
 	processes map[ProcessID]*ProcessInfo
 	mu        sync.Mutex
@@ -82,12 +83,13 @@ const (
 )
 
 // NewProcessManager creates an ProcessManager.
-func NewProcessManager(ctx context.Context, registry *timemachine.Registry, runtime wazero.Runtime, serverFactory *ServerFactory) *ProcessManager {
+func NewProcessManager(ctx context.Context, registry *timemachine.Registry, runtime wazero.Runtime, serverFactory *ServerFactory, adapter func(ProcessID, wasi.System) wasi.System) *ProcessManager {
 	r := &ProcessManager{
 		registry:      registry,
 		runtime:       runtime,
 		serverFactory: serverFactory,
 		processes:     map[ProcessID]*ProcessInfo{},
+		adapter:       adapter,
 	}
 	r.group, ctx = errgroup.WithContext(ctx)
 	r.ctx, r.cancel = context.WithCancelCause(ctx)
@@ -187,6 +189,9 @@ func (pm *ProcessManager) Start(moduleSpec ModuleSpec, logSpec *LogSpec) (Proces
 		processID = logSpec.ProcessID
 	} else {
 		processID = uuid.New()
+	}
+	if pm.adapter != nil {
+		system = pm.adapter(processID, system)
 	}
 
 	if logSpec != nil {


### PR DESCRIPTION
This PR takes a first pass at implementing fault injection when running guest modules by implementing the following fault emulators:
- a low entropy random data source
- an artificial clock drift
- a partial success of read/write operations
- an error generator that triggers EIO or shutdown of sockets

The configuration is minimal right now, it's just a ratio representing the strength of errors injected into the system.

I did not introduce a lot of knobs because I don't think we know enough yet about the settings we'll want to control and the interface we'll need, the intention is that we will add this later.