### PR TITLE
py: publish vanilla CPython build

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'python/*'
+      - '.github/workflows/python.yaml'
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -51,6 +51,40 @@ jobs:
           aws s3 cp python/cpython/python.wasm                 s3://timecraft/python/main/python.wasm
           aws s3 cp python/cpython/usr/local/lib/python311.zip s3://timecraft/python/main/python311.zip
 
+  build_vanilla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Build docker image
+        working-directory: python
+        run: |
+          docker build -t builder .
+      - name: Compile
+        working-directory: python
+        run: |
+          docker run -v `pwd`:/src -w /src -e NO_OPT=true -e NO_WASMEDGE=true builder ./build.sh
+      - name: Check for output
+        run: |
+          find . -name python.wasm
+          find . -name python311.zip
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Copy build output to public S3
+        run: |
+          aws s3 cp python/cpython/python.wasm                 s3://timecraft/python-vanilla/$GITHUB_SHA/python.wasm
+          aws s3 cp python/cpython/usr/local/lib/python311.zip s3://timecraft/python-vanilla/$GITHUB_SHA/python311.zip
+      - name: Copy build output to public S3 main
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          aws s3 cp python/cpython/python.wasm                 s3://timecraft/python-vanilla/main/python.wasm
+          aws s3 cp python/cpython/usr/local/lib/python311.zip s3://timecraft/python-vanilla/main/python311.zip
+
   docker-build:
     runs-on: ubuntu-latest
     env:
@@ -77,4 +111,3 @@ jobs:
       working-directory: python
       run: |
         echo "noop: make docker-buildx"
-

--- a/python/README.md
+++ b/python/README.md
@@ -97,6 +97,9 @@ export RL=/usr/lib/llvm-15/bin/llvm-ranlib
 If you want to iterate faster, disable the `wasm-opt` pass by providing any
 value to `NO_OPT` when building.
 
+Set the `NO_WASMEDGE` environment variable to build CPython without socket
+support.
+
 When making any change in configuration, it is possible you may have to run
 `make dist-clean` in `/python`.
 

--- a/python/build.sh
+++ b/python/build.sh
@@ -23,15 +23,17 @@ if [ ! -z "${DEBUG}" ]; then
     WASMEDGE_DEBUG="-DWASMEDGE_SOCKET_DEBUG"
 fi
 
-WASMEDGE_LIB="`pwd`/wasmedge_sock/build"
-WASMEDGE_INCLUDE="`pwd`/wasmedge_sock/include"
-mkdir -p "${WASMEDGE_LIB}"
-pushd "${WASMEDGE_LIB}"
-rm -f *.a *.o
-${CC} -Wall -Werror -O0 -MD -MT -MF -c --target=wasm32-unknown-wasi --sysroot=${SYSROOT} -I`pwd`/../include ${WASMEDGE_DEBUG} ../wasi_socket_ext.c -fPIC -o libwasmedge.o
-${AR} qc libwasmedge_sock.a libwasmedge.o
-${RL} libwasmedge_sock.a
-popd
+if [ -z "${NO_WASMEDGE}" ]; then
+    WASMEDGE_LIB="`pwd`/wasmedge_sock/build"
+    WASMEDGE_INCLUDE="`pwd`/wasmedge_sock/include"
+    mkdir -p "${WASMEDGE_LIB}"
+    pushd "${WASMEDGE_LIB}"
+    rm -f *.a *.o
+    ${CC} -Wall -Werror -O0 -MD -MT -MF -c --target=wasm32-unknown-wasi --sysroot=${SYSROOT} -I`pwd`/../include ${WASMEDGE_DEBUG} ../wasi_socket_ext.c -fPIC -o libwasmedge.o
+    ${AR} qc libwasmedge_sock.a libwasmedge.o
+    ${RL} libwasmedge_sock.a
+    popd
+fi
 
 export MYBUILD="`pwd`/build"
 
@@ -75,8 +77,13 @@ export LDFLAGS="-L${LIBZ_LIB} ${LDFLAGS}"
 export CFLAGS="-I${LIBUUID_INCLUDE} ${CFLAGS}"
 export LDFLAGS="-L${LIBUUID_LIB} ${LDFLAGS}"
 
-export CFLAGS="-I${WASMEDGE_INCLUDE} --sysroot=${SYSROOT} ${CFLAGS}"
-export LDFLAGS="-lwasmedge_sock -L${WASMEDGE_LIB} ${LDFLAGS}"
+export CFLAGS="--sysroot=${SYSROOT} ${CFLAGS}"
+
+if [ -z "${NO_WASMEDGE}" ]; then
+    export CFLAGS="-I${WASMEDGE_INCLUDE} ${CFLAGS}"
+    export LDFLAGS="-lwasmedge_sock -L${WASMEDGE_LIB} ${LDFLAGS}"
+fi
+
 export PYTHON_WASM_CONFIGURE="--with-build-python=python3.11"
 
 if [ ! -z "${DEBUG}" ]; then


### PR DESCRIPTION
Provide a vanilla (no wasmedge) CPython build for restricted environments such as wzprof test suite. Hopefully, vmware will eventually publish non-wasm-opt'd builds so that we can use those instead. In the meantime this should be good enough.

Also added the workflow file itself to the the trigger list cc @Pryz 