### PR TITLE
sandbox: add file limits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/klauspost/compress v1.16.6
 	github.com/planetscale/vtprotobuf v0.4.0
 	github.com/stealthrocket/net v0.2.1
-	github.com/stealthrocket/wasi-go v0.7.2
+	github.com/stealthrocket/wasi-go v0.7.5
 	github.com/stealthrocket/wazergo v0.19.1
 	github.com/stealthrocket/wzprof v0.1.5
 	github.com/tetratelabs/wazero v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/planetscale/vtprotobuf v0.4.0/go.mod h1:wm1N3qk9G/4+VM1WhpkLbvY/d8+0P
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stealthrocket/net v0.2.1 h1:PehPGAAjuV46zaeHGlNgakFV7QDGUAREMcEQsZQ8NLo=
 github.com/stealthrocket/net v0.2.1/go.mod h1:VvoFod9pYC9mo+bEg2NQB/D+KVOjxfhZjZ5zyvozq7M=
-github.com/stealthrocket/wasi-go v0.7.2 h1:7QIYqI5oLciiImKov3JhSbZjg5su7uKzxrCfzPxrNKg=
-github.com/stealthrocket/wasi-go v0.7.2/go.mod h1:PJ5oVs2E1ciOJnsTnav4nvTtEcJ4D1jUZAewS9pzuZg=
+github.com/stealthrocket/wasi-go v0.7.5 h1:UP5zVXI6ifbGIPEmbM9S28DUHL25jvrvawMRDoYXuVQ=
+github.com/stealthrocket/wasi-go v0.7.5/go.mod h1:PJ5oVs2E1ciOJnsTnav4nvTtEcJ4D1jUZAewS9pzuZg=
 github.com/stealthrocket/wazergo v0.19.1 h1:BPrITETPgSFwiytwmToO0MbUC/+RGC39JScz1JmmG6c=
 github.com/stealthrocket/wazergo v0.19.1/go.mod h1:riI0hxw4ndZA5e6z7PesHg2BtTftcZaMxRcoiGGipTs=
 github.com/stealthrocket/wzprof v0.1.5 h1:abEwQF9KtqV7UQ0hWk7431vul9/FxOg1eRCqwEKo9/4=

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -33,6 +33,8 @@ func TestSandboxSystem(t *testing.T) {
 			sandbox.Environ(config.Environ...),
 			sandbox.Rand(config.Rand),
 			sandbox.Time(config.Now),
+			sandbox.MaxOpenFiles(config.MaxOpenFiles),
+			sandbox.MaxOpenDirs(config.MaxOpenDirs),
 		}
 
 		if config.RootFS != "" {


### PR DESCRIPTION
Implement limits introduced in https://github.com/stealthrocket/wasi-go/pull/84

This is not yet wired to the timecraft CLI, I'm just adding the feature in the sandbox library code as an incremental step because I refactored the code a bit (mainly changed the `FileTable` field not to be embedded in the `sandbox.System` type).