### PR TITLE
timecraft: expose process id in json and yaml output

### DIFF
--- a/format/timecraft.go
+++ b/format/timecraft.go
@@ -198,7 +198,7 @@ func jsonDecode(b []byte, value any) error {
 }
 
 type Manifest struct {
-	ProcessID UUID         `json:"-"                  yaml:"-"`
+	ProcessID UUID         `json:"id,omitempty"       yaml:"id,omitempty"`
 	StartTime time.Time    `json:"startTime"          yaml:"startTime"`
 	Process   *Descriptor  `json:"process"            yaml:"process"`
 	Segments  []LogSegment `json:"segments,omitempty" yaml:"segments,omitempty"`


### PR DESCRIPTION
Fixes #181 

I couldn't figure out why we didn't expose it, but it seems like it would be useful to have the process id displayed in the output of `timecraft get ps -o json`.
