### PR TITLE
ci: fix glob pattern for python build trigger

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -3,7 +3,7 @@ name: Python
 on:
   push:
     paths:
-      - 'python/*'
+      - 'python/**'
       - '.github/workflows/python.yaml'
 
 permissions:


### PR DESCRIPTION
Need to run the Python build on any file in /python, not just the subdirectory (I believe this is why the build didn't run on https://github.com/stealthrocket/timecraft/pull/187).