### PR TITLE
tarfs: do not store file names

### DIFF
--- a/internal/sandbox/tarfs/placeholder.go
+++ b/internal/sandbox/tarfs/placeholder.go
@@ -14,7 +14,7 @@ type placeholder struct {
 	info sandbox.FileInfo
 }
 
-func (p *placeholder) open(fsys *FileSystem) (sandbox.File, error) {
+func (p *placeholder) open(fsys *FileSystem, name string) (sandbox.File, error) {
 	return nil, syscall.EPERM
 }
 

--- a/internal/sandbox/tarfs/symlink.go
+++ b/internal/sandbox/tarfs/symlink.go
@@ -8,12 +8,11 @@ import (
 )
 
 type symlink struct {
-	name string
 	link string
 	info sandbox.FileInfo
 }
 
-func (s *symlink) open(fsys *FileSystem) (sandbox.File, error) {
+func (s *symlink) open(fsys *FileSystem, name string) (sandbox.File, error) {
 	return nil, sandbox.ELOOP
 }
 
@@ -26,5 +25,5 @@ func (s *symlink) mode() fs.FileMode {
 }
 
 func (s *symlink) memsize() uintptr {
-	return unsafe.Sizeof(symlink{}) + uintptr(len(s.name)) + uintptr(len(s.link))
+	return unsafe.Sizeof(symlink{}) + uintptr(len(s.link))
 }


### PR DESCRIPTION
This PR is a small optimization to reduce the memory footprint of tar file systems, instead of storing the file names, we can recompute them when opening files. This means that we only use memory to hold this field for open files instead of doing it for all files in the file system.

This yields a 23% reduction in the memory footprint needed to load alpine 3.18.2:
```
=== RUN   TestAlpine
    tarfs_test.go:77: Size     = 5577728
    tarfs_test.go:78: Memsize  = 108909 (1.83%)
    tarfs_test.go:79: Filesize = 5290340 (94.85%)
```
```
=== RUN   TestAlpine
    tarfs_test.go:77: Size     = 5577728
    tarfs_test.go:78: Memsize  = 90935 (1.51%)
    tarfs_test.go:79: Filesize = 5290340 (94.85%)
```