### PR TITLE
tarfs: reduce the size of file stats

### DIFF
--- a/internal/sandbox/tarfs/symlink.go
+++ b/internal/sandbox/tarfs/symlink.go
@@ -1,15 +1,33 @@
 package tarfs
 
 import (
+	"archive/tar"
 	"io/fs"
+	"time"
 	"unsafe"
 
 	"github.com/stealthrocket/timecraft/internal/sandbox"
 )
 
 type symlink struct {
-	link string
-	info sandbox.FileInfo
+	perm  fs.FileMode
+	nlink uint32
+	mtime int64
+	atime int64
+	ctime int64
+	link  string
+}
+
+func newSymlink(header *tar.Header) *symlink {
+	mode := header.FileInfo().Mode()
+	return &symlink{
+		perm:  mode.Perm() & 0555,
+		nlink: 1,
+		mtime: header.ModTime.UnixNano(),
+		atime: header.AccessTime.UnixNano(),
+		ctime: header.ChangeTime.UnixNano(),
+		link:  header.Linkname,
+	}
 }
 
 func (s *symlink) open(fsys *FileSystem, name string) (sandbox.File, error) {
@@ -17,11 +35,19 @@ func (s *symlink) open(fsys *FileSystem, name string) (sandbox.File, error) {
 }
 
 func (s *symlink) stat() sandbox.FileInfo {
-	return s.info
+	return sandbox.FileInfo{
+		Mode:  s.mode(),
+		Uid:   1,
+		Gid:   1,
+		Nlink: uint64(s.nlink),
+		Mtime: sandbox.TimeToTimespec(time.Unix(0, s.mtime)),
+		Atime: sandbox.TimeToTimespec(time.Unix(0, s.atime)),
+		Ctime: sandbox.TimeToTimespec(time.Unix(0, s.ctime)),
+	}
 }
 
 func (s *symlink) mode() fs.FileMode {
-	return s.info.Mode
+	return fs.ModeSymlink | s.perm
 }
 
 func (s *symlink) memsize() uintptr {


### PR DESCRIPTION
Based on #195, this PR reduces the memory footprint by storing only the relevant file metadata for each file type:
- do not store the uid/gid since we don't have a use case for it, when we do it will probably make more sense to set the values to something that look like the files belong to the current process since the rootfs we create is intended to be accessible
- store the times as a count of nanosecond instead of a timespec, which halves the amount of memory needed to store hold the times
- only store sizes for regular files since directories and symlinks do not have data on disk

The change yields a 36% reduction from the parent branch, for a total of 47% from the original implementation.

```
=== RUN   TestAlpine
    tarfs_test.go:77: Size     = 5577728
    tarfs_test.go:78: Memsize  = 90935 (1.51%)
    tarfs_test.go:79: Filesize = 5290340 (94.85%)
```
```
=== RUN   TestAlpine
    tarfs_test.go:77: Size     = 5577728
    tarfs_test.go:78: Memsize  = 58543 (0.95%)
    tarfs_test.go:79: Filesize = 5290340 (94.85%)
```