### PR TITLE
tarfs: use null-terminated strings for directory entries

### DIFF
--- a/internal/sandbox/tarfs/dir.go
+++ b/internal/sandbox/tarfs/dir.go
@@ -43,7 +43,7 @@ func makeDir(modTime time.Time) dir {
 }
 
 type dirEntry struct {
-	name string
+	name cstring
 	file fileEntry
 }
 
@@ -80,7 +80,7 @@ func (d *dir) memsize() uintptr {
 	size := unsafe.Sizeof(dir{})
 	for _, ent := range d.ents {
 		size += unsafe.Sizeof(ent)
-		size += uintptr(len(ent.name))
+		size += uintptr(ent.name.len() + 1)
 	}
 	return size
 }
@@ -93,9 +93,9 @@ func (d *dir) find(name string) fileEntry {
 		return d.parent
 	}
 	i := sort.Search(len(d.ents), func(i int) bool {
-		return d.ents[i].name >= name
+		return d.ents[i].name.string() >= name
 	})
-	if i == len(d.ents) || d.ents[i].name != name {
+	if i == len(d.ents) || d.ents[i].name.string() != name {
 		return nil
 	}
 	return d.ents[i].file
@@ -276,7 +276,7 @@ func (d *openDir) ReadDirent(buf []byte) (int, error) {
 	}
 
 	for i := d.index - 2; i < len(dir.ents) && n < len(buf); i++ {
-		name := dir.ents[i].name
+		name := dir.ents[i].name.string()
 		file := dir.ents[i].file
 		wn := sandbox.WriteDirent(buf[n:], file.mode(), 0, d.offset, name)
 		n += wn


### PR DESCRIPTION
I'm opening this PR just because I wanted to measure the impact of the change, but I don't think it's worth the amount of unsafe operation it introduces; I'll close it for now but we can bring it back if we ever have a stronger use case for it.

---

Based on #197, this PR represents directory entry names as null-terminated strings to reduce their memory footprint. Go strings are stored as a pair of pointer and length, which holds 16 bytes on 64 bits architectures. By using C-style strings we only need one extra byte to represent the end of string, reducing the overhead to 9 bytes per string instead.

To ensure that we are banking the savings, a simple allocator packs small strings next to each other in memory and avoids the overhead of metadata maintained by the Go memory allocator.

The optimization reduces the memory footprint of the Alpine file system by 7% compared to the parent branch, totaling 65% reduction from the first implementation:
```
=== RUN   TestAlpine
    tarfs_test.go:77: Size     = 5577728
    tarfs_test.go:78: Memsize  = 52761 (0.95%)
    tarfs_test.go:79: Filesize = 5290340 (94.85%)
```
```
=== RUN   TestAlpine
    tarfs_test.go:77: Size     = 5577728
    tarfs_test.go:78: Memsize  = 49149 (0.88%)
    tarfs_test.go:79: Filesize = 5290340 (94.85%)
```