### PR TITLE
sandbox: use fast path to open root directories

### DIFF
--- a/internal/sandbox/fspath/fspath.go
+++ b/internal/sandbox/fspath/fspath.go
@@ -2,6 +2,8 @@
 // that are more useful for path manipulation in the presence of symbolic links.
 package fspath
 
+import "strings"
+
 // Depth returns the depth of a path. The root "/" has depth zero.
 func Depth(path string) (depth int) {
 	for {
@@ -145,6 +147,33 @@ func TrimTrailingSlash(s string) string {
 	return s[:i]
 }
 
+// IsAbs returns true if the path is absolute, which means that it starts with
+// a slash ("/").
 func IsAbs(path string) bool {
 	return len(path) > 0 && path[0] == '/'
+}
+
+// IsRoot returns true if the path represents a root directory, which means that
+// it is absolute and composed only of sequences of "/", ".", and "..".
+func IsRoot(path string) bool {
+	if len(path) == 0 || path[0] != '/' {
+		return false
+	}
+	for {
+		path = TrimLeadingSlash(path)
+		switch {
+		case path == "":
+			return true
+		case strings.HasPrefix(path, "./"):
+			path = path[2:]
+		case strings.HasPrefix(path, "../"):
+			path = path[3:]
+		case path == ".":
+			path = path[1:]
+		case path == "..":
+			path = path[2:]
+		default:
+			return false
+		}
+	}
 }

--- a/internal/sandbox/fspath/fspath_test.go
+++ b/internal/sandbox/fspath/fspath_test.go
@@ -1,6 +1,7 @@
 package fspath_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stealthrocket/timecraft/internal/assert"
@@ -84,5 +85,33 @@ func TestClean(t *testing.T) {
 func BenchmarkClean(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = fspath.Clean("/tmp/.././//test/")
+	}
+}
+
+func TestIsRoot(t *testing.T) {
+	tests := []struct {
+		path   string
+		isRoot bool
+	}{
+		{"", false},
+		{".", false},
+		{"..", false},
+
+		{"/", true},
+		{"///", true},
+		{"/./././", true},
+		{"/..", true},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s=%t", test.path, test.isRoot), func(t *testing.T) {
+			assert.Equal(t, fspath.IsRoot(test.path), test.isRoot)
+		})
+	}
+}
+
+func BenchmarkIsRoot(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = fspath.IsRoot("/././././")
 	}
 }

--- a/internal/sandbox/ocifs/ocifs.go
+++ b/internal/sandbox/ocifs/ocifs.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 
 	"github.com/stealthrocket/timecraft/internal/sandbox"
+	"github.com/stealthrocket/timecraft/internal/sandbox/fspath"
 )
 
 // FileSystem is an implementation of the sandbox.FileSystem interface that
@@ -39,6 +40,9 @@ func (fsys *FileSystem) Open(name string, flags int, mode fs.FileMode) (sandbox.
 	f, err := fsys.openRoot()
 	if err != nil {
 		return nil, err
+	}
+	if fspath.IsRoot(name) {
+		return f, nil
 	}
 	defer f.Close()
 	return f.Open(name, flags, mode)

--- a/internal/sandbox/rootfs.go
+++ b/internal/sandbox/rootfs.go
@@ -27,6 +27,9 @@ func (fsys *rootFS) Open(name string, flags int, mode fs.FileMode) (File, error)
 	if err != nil {
 		return nil, err
 	}
+	if fspath.IsRoot(name) {
+		return &rootFile{f}, nil
+	}
 	defer f.Close()
 	return (&rootFile{f}).Open(name, flags, mode)
 }

--- a/internal/sandbox/tarfs/tarfs.go
+++ b/internal/sandbox/tarfs/tarfs.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stealthrocket/timecraft/internal/sandbox"
+	"github.com/stealthrocket/timecraft/internal/sandbox/fspath"
 	"golang.org/x/exp/slices"
 )
 
@@ -28,6 +29,9 @@ func (fsys *FileSystem) Open(name string, flags int, mode fs.FileMode) (sandbox.
 	f, err := fsys.root.open(fsys, "/")
 	if err != nil {
 		return nil, err
+	}
+	if fspath.IsRoot(name) {
+		return f, nil
 	}
 	defer f.Close()
 	return f.Open(name, flags, mode)


### PR DESCRIPTION
Opening the root directory of file systems is a common operation since all path resolution needs to start at the root. The current implementations were always opening the root twice: once to start path resolution, and once because the target of path resolution was the root itself.

This PR modifies the file systems to take a shortcut: when the file being opened is the root directory, return it immediately instead of entering the path resolution stage.