### PR TITLE
sandbox: make DirFS a root file system

### DIFF
--- a/internal/sandbox/dirfs.go
+++ b/internal/sandbox/dirfs.go
@@ -6,4 +6,8 @@ package sandbox
 // The returned FileSystem instance captures the path passed as argument as-is.
 // If the path is relative, the resulting FileSystem depends on the program's
 // current working directory when opening files.
-func DirFS(path string) FileSystem { return dirFS(path) }
+//
+// As long as the directory that the file system is opened on does not change,
+// it prevents escaping from it, even in the presence of symbolic links
+// referencing paths above the root directory.
+func DirFS(path string) FileSystem { return &dirFS{root: path} }

--- a/internal/sandbox/dirfs_test.go
+++ b/internal/sandbox/dirfs_test.go
@@ -15,7 +15,13 @@ func TestDirFS(t *testing.T) {
 		})
 	})
 
-	sandboxtest.TestFileSystem(t, func(t *testing.T) sandbox.FileSystem {
-		return sandbox.DirFS(t.TempDir())
+	t.Run("sandbox.FileSystem", func(t *testing.T) {
+		sandboxtest.TestFileSystem(t, func(t *testing.T) sandbox.FileSystem {
+			return sandbox.DirFS(t.TempDir())
+		})
+	})
+
+	sandboxtest.TestRootFS(t, func(t *testing.T, path string) sandbox.FileSystem {
+		return sandbox.DirFS(path)
 	})
 }

--- a/internal/sandbox/ocifs/ocifs.go
+++ b/internal/sandbox/ocifs/ocifs.go
@@ -48,7 +48,7 @@ func (fsys *FileSystem) Open(name string, flags int, mode fs.FileMode) (sandbox.
 	return f.Open(name, flags, mode)
 }
 
-func (fsys *FileSystem) openRoot() (*file, error) {
+func (fsys *FileSystem) openRoot() (sandbox.File, error) {
 	if len(fsys.layers) == 0 {
 		return nil, sandbox.ENOENT
 	}


### PR DESCRIPTION
Based on #206, this PR modifies the `sandbox.DirFS` implementation to become a root file system (one that the guest cannot escape by referencing the root's parent directory).

The change is done by reusing `sandbox.ResolvePath` for all path resolutions instead of letting the kernel handle it.

Consequently, existing wasm modules spawned by timecraft will now be sandboxed to the preopen directories, incapable of navigating the rest of the host file system. It will keep everything the same for use cases where we mount the host root file system.