### PR TITLE
sandbox: concurrent-safe dirfs

### DIFF
--- a/internal/sandbox/dirfs_unix.go
+++ b/internal/sandbox/dirfs_unix.go
@@ -61,10 +61,10 @@ func (f *dirFile) acquire() int {
 		// so we can coordinate with other reference counters that may have
 		// unreferenced the file down to zero due to a concurrent Close call.
 		if f.refc.CompareAndSwap(refCount, refCount+1) {
-			// If Close was called concurrently, we might observe a zero once
-			// at this stage, which indicates that we should abort the operation
-			// and dereference the file, which might cause the file descriptor
-			// to be closed.
+			// If Close was called concurrently, we might observe a non-zero
+			// once at this stage, which indicates that we should abort the
+			// operation and dereference the file, which might cause the file
+			// descriptor to be closed.
 			if f.once.Load() != 0 {
 				f.unref()
 				return -1

--- a/internal/sandbox/fs.go
+++ b/internal/sandbox/fs.go
@@ -29,6 +29,9 @@ const (
 // system, which may be a directory. Often time this method is used to open the
 // root directory and use the methods of the returned File instance to access
 // the rest of the directory tree.
+//
+// FileSystem implementations must be safe for concurrent use by multiple
+// goroutines.
 type FileSystem interface {
 	Open(name string, flags OpenFlags, mode fs.FileMode) (File, error)
 }
@@ -294,6 +297,8 @@ func withRoot2[R any](fsys FileSystem, do func(File) (R, error)) (ret R, err err
 }
 
 // File is an interface representing files opened from a file system.
+//
+// File implementations must be safe for concurrent use by multiple goroutines.
 type File interface {
 	// Returns the file descriptor number for the underlying kernel handle for
 	// the file.


### PR DESCRIPTION
This PR modifies the `DirFS` implementation to be safe for use by multiple goroutines. While this is not strictly necessary for the WASI use case, @Pryz mentioned he wanted to look at integrating this with #183, and all other `sandbox.FileSystem` implementation are safe for concurrent use, and it is likely an assumption of anyone using a file system that concurrent access are safe.

Concurrency-safety is achieved by acquiring a reference to the file before performing any operations. After acquiring a reference, we check if the file has been closed (its `once` value is not zero). If that is the case, we mask the file descriptor, which might still be valid, but should not be used anymore. The only valid use of a file descriptor on a closed file is duplicating it during path lookups of parent or root directories (see `(*dirFile).openSelf`).