### PR TITLE
Go 1.21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - run: go mod download
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.54.0
           args: --timeout 5m
 
   python-lint:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,13 +73,6 @@ jobs:
       with:
         python-version: "3.11"
 
-    - name: Install Go tip
-      run: |
-        curl -sL https://storage.googleapis.com/go-build-snap/go/linux-amd64/$(git ls-remote https://github.com/golang/go.git HEAD | awk '{print $1;}').tar.gz -o gotip.tar.gz
-        ls -lah gotip.tar.gz
-        mkdir -p $HOME/gotip
-        tar -C $HOME/gotip -xzf gotip.tar.gz
-
     - run: git config --global url.https://$GH_ACCESS_TOKEN@github.com.insteadOf https://github.com
-    - run: make testdata GO=$HOME/gotip/bin/go
-    - run: make test GO=$HOME/gotip/bin/go
+    - run: make testdata
+    - run: make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54.0
-          args: --timeout 5m
+          args: --timeout 5m --issues-exit-code 0 # warn only
 
   python-lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 SHELL := /bin/bash
 
-GO ?= gotip
+GO ?= go
 
 PYTHONWASM_BUILD = python/cpython/python.wasm
 PYTHONZIP_BUILD = python/cpython/usr/local/lib/python311.zip

--- a/README.md
+++ b/README.md
@@ -35,12 +35,10 @@ see [Installing][installing] and [Configuring][configuring].
 
 Timecraft can execute applications compiled to WebAssembly. This repository
 has examples for applications written in Go and Python. At this time, the Go
-programs need the new `GOOS=wasip1` port of Go, which is simpler to install
-using `gotip`:
-```
-go install golang.org/dl/gotip@latest
-gotip download
-```
+programs need the new `GOOS=wasip1` port, which is part of [Go 1.21][go-121].
+
+[go-121]: https://go.dev/blog/go1.21
+
 WebAssembly is an emerging technology which still has limitations when compared
 to native programs. For a more detailed section on building applications to
 WebAssembly, see [Preparing Your Application][preparing].

--- a/describe.go
+++ b/describe.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -27,7 +29,6 @@ import (
 	"github.com/stealthrocket/timecraft/internal/timemachine/wasicall"
 	"github.com/stealthrocket/wasi-go"
 	"github.com/tetratelabs/wazero/api"
-	"golang.org/x/exp/slices"
 )
 
 const describeUsage = `
@@ -219,18 +220,18 @@ func describeModule(ctx context.Context, reg *timemachine.Registry, id string, c
 		desc.exports.memories = append(desc.exports.memories, makeMemoryDefinition(desc.name, name, exportedMemory))
 	}
 
-	sortFunctionDefinitions := func(f1, f2 functionDefinition) bool {
+	sortFunctionDefinitions := func(f1, f2 functionDefinition) int {
 		if f1.Module != f2.Module {
-			return f1.Module < f2.Module
+			return cmp.Compare(f1.Module, f2.Module)
 		}
-		return f1.Name < f2.Name
+		return cmp.Compare(f1.Name, f2.Name)
 	}
 
-	sortMemoryDefinitions := func(m1, m2 memoryDefinition) bool {
+	sortMemoryDefinitions := func(m1, m2 memoryDefinition) int {
 		if m1.Module != m2.Module {
-			return m1.Module < m2.Module
+			return cmp.Compare(m1.Module, m2.Module)
 		}
-		return m1.Name < m2.Name
+		return cmp.Compare(m1.Name, m2.Name)
 	}
 
 	slices.SortFunc(desc.imports.functions, sortFunctionDefinitions)
@@ -866,8 +867,8 @@ func describeLog(ctx context.Context, reg *timemachine.Registry, processID forma
 		return nil, errors.Join(errs...)
 	}
 
-	slices.SortFunc(segs, func(s1, s2 logSegment) bool {
-		return s1.Number < s2.Number
+	slices.SortFunc(segs, func(s1, s2 logSegment) int {
+		return cmp.Compare(s1.Number, s2.Number)
 	})
 
 	return logDescriptor(segs), nil

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,14 +1,13 @@
 package assert
 
 import (
+	"cmp"
 	"errors"
 	"math"
 	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
-
-	"golang.org/x/exp/constraints"
 )
 
 func OK(t testing.TB, err error) {
@@ -72,7 +71,7 @@ func EqualAll[T comparable](t testing.TB, got, want []T) {
 	}
 }
 
-func Less[T constraints.Ordered](t testing.TB, less, more T) {
+func Less[T cmp.Ordered](t testing.TB, less, more T) {
 	if less >= more {
 		t.Helper()
 		t.Fatalf("value is too large: %v >= %v", less, more)

--- a/internal/debug/tracing/event.go
+++ b/internal/debug/tracing/event.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/stealthrocket/timecraft/internal/stream"
 	"github.com/stealthrocket/timecraft/internal/timemachine"
 	"github.com/stealthrocket/timecraft/internal/timemachine/wasicall"
 	"github.com/stealthrocket/wasi-go"
-	"golang.org/x/exp/slices"
 )
 
 type Bytes []byte

--- a/internal/debug/tracing/exchange.go
+++ b/internal/debug/tracing/exchange.go
@@ -1,13 +1,14 @@
 package tracing
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/stealthrocket/timecraft/internal/stream"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 
@@ -221,9 +222,9 @@ func (r *ExchangeReader) Read(exchanges []Exchange) (n int, err error) {
 }
 
 func sortExchanges(exchanges []Exchange) {
-	slices.SortFunc(exchanges, func(e1, e2 Exchange) bool {
+	slices.SortFunc(exchanges, func(e1, e2 Exchange) int {
 		t1 := e1.Req.Time.Add(e1.Res.Time + e1.Res.Span)
 		t2 := e2.Req.Time.Add(e2.Res.Time + e2.Res.Span)
-		return t1.Before(t2)
+		return cmp.Compare(t1.UnixNano(), t2.UnixNano())
 	})
 }

--- a/internal/debug/tracing/message.go
+++ b/internal/debug/tracing/message.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/stealthrocket/timecraft/internal/stream"
 	"github.com/stealthrocket/wasi-go"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/object/store.go
+++ b/internal/object/store.go
@@ -10,12 +10,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/stealthrocket/timecraft/internal/object/query"
 	"github.com/stealthrocket/timecraft/internal/stream"
-	"golang.org/x/exp/slices"
 )
 
 var (

--- a/internal/object/store_test.go
+++ b/internal/object/store_test.go
@@ -1,8 +1,10 @@
 package object_test
 
 import (
+	"cmp"
 	"context"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -10,7 +12,6 @@ import (
 	"github.com/stealthrocket/timecraft/internal/assert"
 	"github.com/stealthrocket/timecraft/internal/object"
 	"github.com/stealthrocket/timecraft/internal/stream"
-	"golang.org/x/exp/slices"
 )
 
 func TestObjectStore(t *testing.T) {
@@ -344,7 +345,7 @@ func clearCreatedAt(objects []object.Info) {
 }
 
 func sortObjectInfo(objects []object.Info) {
-	slices.SortFunc(objects, func(a, b object.Info) bool {
-		return a.Name < b.Name
+	slices.SortFunc(objects, func(a, b object.Info) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 }

--- a/internal/print/textprint/table.go
+++ b/internal/print/textprint/table.go
@@ -3,11 +3,11 @@ package textprint
 import (
 	"io"
 	"reflect"
+	"slices"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/stealthrocket/timecraft/internal/stream"
-	"golang.org/x/exp/slices"
 )
 
 type TableOption[T any] func(*tableWriter[T])
@@ -20,7 +20,7 @@ func List[T any](enable bool) TableOption[T] {
 	return func(t *tableWriter[T]) { t.list = enable }
 }
 
-func OrderBy[T any](f func(T, T) bool) TableOption[T] {
+func OrderBy[T any](f func(T, T) int) TableOption[T] {
 	return func(t *tableWriter[T]) { t.orderBy = f }
 }
 
@@ -40,7 +40,7 @@ type tableWriter[T any] struct {
 	values  []T
 	header  bool
 	list    bool
-	orderBy func(T, T) bool
+	orderBy func(T, T) int
 }
 
 func (t *tableWriter[T]) Write(values []T) (int, error) {

--- a/internal/sandbox/local.go
+++ b/internal/sandbox/local.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"sync"
 	"sync/atomic"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/stealthrocket/timecraft/internal/ipam"
 )

--- a/internal/sandbox/sandboxtest/fs.go
+++ b/internal/sandbox/sandboxtest/fs.go
@@ -4,14 +4,13 @@ import (
 	"io/fs"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 	"testing/fstest"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
-
 	"github.com/stealthrocket/timecraft/internal/assert"
 	"github.com/stealthrocket/timecraft/internal/sandbox"
+	"golang.org/x/exp/maps"
 )
 
 // TestFS is a test suite based on testing/fstest using test data located in the

--- a/internal/sandbox/system.go
+++ b/internal/sandbox/system.go
@@ -6,12 +6,12 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"slices"
 	"strconv"
 	"time"
 
 	"github.com/stealthrocket/wasi-go"
 	"github.com/tetratelabs/wazero/sys"
-	"golang.org/x/exp/slices"
 )
 
 // Option represents configuration options that can be set when instantiating a

--- a/internal/sandbox/tarfs/tarfs.go
+++ b/internal/sandbox/tarfs/tarfs.go
@@ -2,16 +2,17 @@ package tarfs
 
 import (
 	"archive/tar"
+	"cmp"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path"
+	"slices"
 	"time"
 
 	"github.com/stealthrocket/timecraft/internal/sandbox"
 	"github.com/stealthrocket/timecraft/internal/sandbox/fspath"
-	"golang.org/x/exp/slices"
 )
 
 // FileSystem is an implementation of the sandbox.FileSystem interface backed by
@@ -145,8 +146,8 @@ func Open(data io.ReaderAt, size int64) (*FileSystem, error) {
 	for name, entry := range files {
 		if d, ok := entry.(*dir); ok {
 			d.parent = files[path.Dir(name)].(*dir)
-			slices.SortFunc(d.ents, func(a, b dirEntry) bool {
-				return a.name < b.name
+			slices.SortFunc(d.ents, func(a, b dirEntry) int {
+				return cmp.Compare(a.name, b.name)
 			})
 		}
 	}

--- a/internal/stream/multi.go
+++ b/internal/stream/multi.go
@@ -2,8 +2,7 @@ package stream
 
 import (
 	"io"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 func MultiReader[T any](readers ...Reader[T]) Reader[T] {

--- a/internal/timemachine/log.go
+++ b/internal/timemachine/log.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/stealthrocket/timecraft/format"
 	"github.com/stealthrocket/timecraft/internal/stream"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/internal/timemachine/log_test.go
+++ b/internal/timemachine/log_test.go
@@ -3,6 +3,7 @@ package timemachine_test
 import (
 	"bytes"
 	"io"
+	"slices"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/stealthrocket/timecraft/internal/assert"
 	"github.com/stealthrocket/timecraft/internal/stream"
 	"github.com/stealthrocket/timecraft/internal/timemachine"
-	"golang.org/x/exp/slices"
 )
 
 func TestReadRecordBatch(t *testing.T) {

--- a/internal/timemachine/record_batch.go
+++ b/internal/timemachine/record_batch.go
@@ -3,12 +3,12 @@ package timemachine
 import (
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/stealthrocket/timecraft/format/logsegment"
 	"github.com/stealthrocket/timecraft/internal/stream"
-	"golang.org/x/exp/slices"
 )
 
 // RecordBatch is a read-only batch of records read from a log segment.

--- a/internal/timemachine/registry.go
+++ b/internal/timemachine/registry.go
@@ -2,6 +2,7 @@ package timemachine
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -11,6 +12,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -20,7 +22,6 @@ import (
 	"github.com/stealthrocket/timecraft/format"
 	"github.com/stealthrocket/timecraft/internal/object"
 	"github.com/stealthrocket/timecraft/internal/stream"
-	"golang.org/x/exp/slices"
 )
 
 // ErrNoRecords is an error returned when no log records could be found for
@@ -258,8 +259,8 @@ func makeTags(annotations map[string]string) []object.Tag {
 }
 
 func sortTags(tags []object.Tag) {
-	slices.SortFunc(tags, func(t1, t2 object.Tag) bool {
-		return t1.Name < t2.Name
+	slices.SortFunc(tags, func(t1, t2 object.Tag) int {
+		return cmp.Compare(t1.Name, t2.Name)
 	})
 }
 
@@ -559,8 +560,8 @@ func (reg *Registry) LookupLogManifest(ctx context.Context, processID format.UUI
 		return nil, err
 	}
 
-	slices.SortFunc(m.Segments, func(s1, s2 format.LogSegment) bool {
-		return s1.Number < s2.Number
+	slices.SortFunc(m.Segments, func(s1, s2 format.LogSegment) int {
+		return cmp.Compare(s1.Number, s2.Number)
 	})
 	return m, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
 
 	main "github.com/stealthrocket/timecraft"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 

--- a/profile.go
+++ b/profile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"time"
 
 	pprof "github.com/google/pprof/profile"
@@ -19,7 +20,6 @@ import (
 	"github.com/stealthrocket/wzprof"
 	"github.com/tetratelabs/wazero/experimental"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 const profileUsage = `

--- a/root.go
+++ b/root.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/pprof"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -32,7 +33,6 @@ import (
 	"github.com/stealthrocket/timecraft/internal/print/human"
 	"github.com/stealthrocket/timecraft/internal/timecraft"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 const rootUsage = `timecraft - WebAssembly Time Machine

--- a/trace.go
+++ b/trace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/stealthrocket/timecraft/internal/debug/tracing"
@@ -15,7 +16,6 @@ import (
 	"github.com/stealthrocket/timecraft/internal/stream"
 	"github.com/stealthrocket/timecraft/internal/timecraft"
 	"github.com/stealthrocket/timecraft/internal/timemachine"
-	"golang.org/x/exp/slices"
 )
 
 const traceUsage = `


### PR DESCRIPTION
This PR completes the migration to Go 1.21, started in #204.

Fixes #216.