### PR TITLE
sandbox: support rename flags

### DIFF
--- a/internal/sandbox/dirfs_unix.go
+++ b/internal/sandbox/dirfs_unix.go
@@ -309,14 +309,14 @@ func (f *dirFile) Rmdir(name string) error {
 	})
 }
 
-func (f1 *dirFile) Rename(oldName string, newDir File, newName string) error {
+func (f1 *dirFile) Rename(oldName string, newDir File, newName string, flags RenameFlags) error {
 	f2, ok := newDir.(*dirFile)
 	if !ok {
 		return EXDEV
 	}
 	return resolvePath1(f1, oldName, AT_SYMLINK_NOFOLLOW, func(fd1 int, name1 string) error {
 		return resolvePath1(f2, newName, AT_SYMLINK_NOFOLLOW, func(fd2 int, name2 string) error {
-			return renameat(fd1, name1, fd2, name2)
+			return renameat(fd1, name1, fd2, name2, flags.sysFlags())
 		})
 	})
 }

--- a/internal/sandbox/flags.go
+++ b/internal/sandbox/flags.go
@@ -13,20 +13,17 @@ func makeOpenFlags(sysFlags int) OpenFlags {
 	return OpenFlags(sysFlags)
 }
 
-func (openFlags OpenFlags) String() string {
+func (of OpenFlags) String() string {
 	var names []string
 
-	switch openFlags & (O_RDWR | O_WRONLY | O_RDONLY) {
+	switch of & (O_RDWR | O_WRONLY | O_RDONLY) {
 	case O_RDWR:
 		names = append(names, "O_RDWR")
 	case O_WRONLY:
 		names = append(names, "O_WRONLY")
 	}
 
-	for _, f := range [...]struct {
-		flag OpenFlags
-		name string
-	}{
+	names = appendFlagNames(names, of, []flagName[OpenFlags]{
 		{O_APPEND, "O_APPEND"},
 		{O_CREAT, "O_CREAT"},
 		{O_EXCL, "O_EXCL"},
@@ -35,52 +32,90 @@ func (openFlags OpenFlags) String() string {
 		{O_DIRECTORY, "O_DIRECTORY"},
 		{O_NOFOLLOW, "O_NOFOLLOW"},
 		{O_NONBLOCK, "O_NONBLOCK"},
-	} {
-		if (openFlags & f.flag) != 0 {
-			names = append(names, f.name)
-		}
-	}
+	})
 
 	if len(names) == 0 {
 		names = append(names, "O_RDONLY")
 	}
 
-	sort.Strings(names)
-	return strings.Join(names, "|")
+	return joinFlagNames(names)
 }
 
-func (openFlags OpenFlags) LookupFlags() LookupFlags {
-	if (openFlags & O_NOFOLLOW) != 0 {
+func (of OpenFlags) LookupFlags() LookupFlags {
+	if (of & O_NOFOLLOW) != 0 {
 		return AT_SYMLINK_NOFOLLOW
 	} else {
 		return 0
 	}
 }
 
-func (openFlags OpenFlags) sysFlags() int {
-	return int(openFlags)
+func (of OpenFlags) sysFlags() int {
+	return int(of)
 }
 
 // LookupFlags is a bitset of flags that can be passed to methods of File and
 // FileSystem values to customize the behavior of file name lookups.
 type LookupFlags int
 
-func (lookupFlags LookupFlags) String() string {
-	if (lookupFlags & AT_SYMLINK_NOFOLLOW) != 0 {
-		return "AT_SYMLINK_NOFOLLOW"
-	} else {
-		return "AT_SYMLINK_FOLLOW"
-	}
+func (lf LookupFlags) String() string {
+	return formatFlagNames(lf, []flagName[LookupFlags]{
+		{AT_SYMLINK_NOFOLLOW, "AT_SYMLINK_NOFOLLOW"},
+	})
 }
 
-func (lookupFlags LookupFlags) OpenFlags() OpenFlags {
-	if (lookupFlags & AT_SYMLINK_NOFOLLOW) != 0 {
+func (lf LookupFlags) OpenFlags() OpenFlags {
+	if (lf & AT_SYMLINK_NOFOLLOW) != 0 {
 		return O_NOFOLLOW
 	} else {
 		return 0
 	}
 }
 
-func (lookupFlags LookupFlags) sysFlags() int {
-	return int(lookupFlags)
+func (lf LookupFlags) sysFlags() int {
+	return int(lf)
+}
+
+// RenameFlags is a bitset of flags passed to the File.Rename method to
+// configure the behavior of the rename operation.
+type RenameFlags int
+
+func (rf RenameFlags) String() string {
+	return formatFlagNames(rf, []flagName[RenameFlags]{
+		{RENAME_EXCHANGE, "RENAME_EXCHANGE"},
+		{RENAME_NOREPLACE, "RENAME_NOREPLACE"},
+	})
+}
+
+func (rf RenameFlags) sysFlags() int {
+	return int(rf)
+}
+
+type flag interface {
+	~int
+}
+
+type flagName[F flag] struct {
+	flag F
+	name string
+}
+
+func formatFlagNames[F flag](flags F, flagNames []flagName[F]) string {
+	return joinFlagNames(appendFlagNames(nil, flags, flagNames))
+}
+
+func appendFlagNames[F flag](names []string, flags F, flagNames []flagName[F]) []string {
+	for _, f := range flagNames {
+		if (flags & f.flag) != 0 {
+			names = append(names, f.name)
+		}
+	}
+	return names
+}
+
+func joinFlagNames(names []string) string {
+	if len(names) == 0 {
+		return "0"
+	}
+	sort.Strings(names)
+	return strings.Join(names, "|")
 }

--- a/internal/sandbox/fs.go
+++ b/internal/sandbox/fs.go
@@ -269,9 +269,9 @@ func Unlink(fsys FileSystem, name string) error {
 
 // Rename changes the name referencing a file, symbolic link, or directory on a
 // file system.
-func Rename(fsys FileSystem, oldName, newName string) error {
+func Rename(fsys FileSystem, oldName, newName string, flags RenameFlags) error {
 	if err := withRoot1(fsys, func(dir File) error {
-		return dir.Rename(oldName, dir, newName)
+		return dir.Rename(oldName, dir, newName, flags)
 	}); err != nil {
 		return &os.LinkError{Op: "rename", Old: oldName, New: newName, Err: err}
 	}
@@ -454,7 +454,7 @@ type File interface {
 	// The new name is interpreted relative to the directory passed as argument,
 	// which may or may not be the same as the receiver, but must be on the same
 	// file system.
-	Rename(oldName string, newDir File, newName string) error
+	Rename(oldName string, newDir File, newName string, flags RenameFlags) error
 
 	// Creates a hard link to a named location.
 	//

--- a/internal/sandbox/ocifs/file.go
+++ b/internal/sandbox/ocifs/file.go
@@ -406,7 +406,7 @@ func (f *file) Rmdir(string) error {
 	return f.expectDirectory()
 }
 
-func (f *file) Rename(string, sandbox.File, string) error {
+func (f *file) Rename(string, sandbox.File, string, sandbox.RenameFlags) error {
 	return f.expectDirectory()
 }
 

--- a/internal/sandbox/sandboxtest/fs_rename.go
+++ b/internal/sandbox/sandboxtest/fs_rename.go
@@ -16,7 +16,7 @@ var fsTestRename = fsTestSuite{
 		assert.OK(t, err)
 		assert.OK(t, d.Close())
 
-		err = d.Rename("test", d, "nope")
+		err = d.Rename("test", d, "nope", 0)
 		assert.Error(t, err, sandbox.EBADF)
 
 		b, err := sandbox.ReadFile(fsys, "test", 0)
@@ -25,14 +25,14 @@ var fsTestRename = fsTestSuite{
 	},
 
 	"renaming a file that does not exist errors with ENOENT": func(t *testing.T, fsys sandbox.FileSystem) {
-		err := sandbox.Rename(fsys, "old", "new")
+		err := sandbox.Rename(fsys, "old", "new", 0)
 		assert.Error(t, err, sandbox.ENOENT)
 	},
 
 	"renaming a file to a location where a file already exists replaces it": func(t *testing.T, fsys sandbox.FileSystem) {
 		assert.OK(t, sandbox.WriteFile(fsys, "one", []byte("1"), 0600))
 		assert.OK(t, sandbox.WriteFile(fsys, "two", []byte("2"), 0600))
-		assert.OK(t, sandbox.Rename(fsys, "two", "one"))
+		assert.OK(t, sandbox.Rename(fsys, "two", "one", 0))
 
 		b, err := sandbox.ReadFile(fsys, "one", 0)
 		assert.OK(t, err)
@@ -45,7 +45,7 @@ var fsTestRename = fsTestSuite{
 	"renaming a file to a location where a symlink already exists replaces it": func(t *testing.T, fsys sandbox.FileSystem) {
 		assert.OK(t, sandbox.Symlink(fsys, "test", "one"))
 		assert.OK(t, sandbox.WriteFile(fsys, "two", []byte("2"), 0600))
-		assert.OK(t, sandbox.Rename(fsys, "two", "one"))
+		assert.OK(t, sandbox.Rename(fsys, "two", "one", 0))
 
 		b, err := sandbox.ReadFile(fsys, "one", 0)
 		assert.OK(t, err)
@@ -59,7 +59,27 @@ var fsTestRename = fsTestSuite{
 		assert.OK(t, sandbox.Mkdir(fsys, "one", 0700))
 		assert.OK(t, sandbox.WriteFile(fsys, "two", []byte("2"), 0600))
 
-		err := sandbox.Rename(fsys, "two", "one")
+		err := sandbox.Rename(fsys, "two", "one", 0)
 		assert.Error(t, err, sandbox.EISDIR)
+	},
+
+	"renaming a file to a location which already exists with RENAME_NOREPLACE errors with EEXIST": func(t *testing.T, fsys sandbox.FileSystem) {
+		assert.OK(t, sandbox.WriteFile(fsys, "one", []byte("1"), 0644))
+		assert.OK(t, sandbox.WriteFile(fsys, "two", []byte("2"), 0644))
+		assert.Error(t, sandbox.Rename(fsys, "two", "one", sandbox.RENAME_NOREPLACE), sandbox.EEXIST)
+	},
+
+	"renaming a file with RENAME_EXCHANGE swaps the source and destination": func(t *testing.T, fsys sandbox.FileSystem) {
+		assert.OK(t, sandbox.WriteFile(fsys, "one", []byte("1"), 0644))
+		assert.OK(t, sandbox.WriteFile(fsys, "two", []byte("2"), 0644))
+		assert.OK(t, sandbox.Rename(fsys, "two", "one", sandbox.RENAME_EXCHANGE))
+
+		b1, err := sandbox.ReadFile(fsys, "one", 0)
+		assert.OK(t, err)
+		assert.Equal(t, string(b1), "2")
+
+		b2, err := sandbox.ReadFile(fsys, "two", 0)
+		assert.OK(t, err)
+		assert.Equal(t, string(b2), "1")
 	},
 }

--- a/internal/sandbox/syscall_linux.go
+++ b/internal/sandbox/syscall_linux.go
@@ -25,8 +25,13 @@ func makeDirent(typ uint8, ino, off uint64, name string) dirent {
 }
 
 const (
-	O_DSYNC = unix.O_DSYNC
-	O_RSYNC = unix.O_RSYNC
+	O_DSYNC OpenFlags = unix.O_DSYNC
+	O_RSYNC OpenFlags = unix.O_RSYNC
+)
+
+const (
+	RENAME_EXCHANGE  RenameFlags = unix.RENAME_EXCHANGE
+	RENAME_NOREPLACE RenameFlags = unix.RENAME_NOREPLACE
 )
 
 const (
@@ -110,4 +115,8 @@ func preadv(fd int, iovs [][]byte, offset int64) (int, error) {
 
 func pwritev(fd int, iovs [][]byte, offset int64) (int, error) {
 	return handleEINTR(func() (int, error) { return unix.Pwritev(fd, iovs, offset) })
+}
+
+func renameat(olddirfd int, oldpath string, newdirfd int, newpath string, flags int) error {
+	return ignoreEINTR(func() error { return unix.Renameat2(olddirfd, oldpath, newdirfd, newpath, uint(flags)) })
 }

--- a/internal/sandbox/syscall_unix.go
+++ b/internal/sandbox/syscall_unix.go
@@ -363,10 +363,6 @@ func mkdirat(dirfd int, path string, mode uint32) error {
 	return ignoreEINTR(func() error { return unix.Mkdirat(dirfd, path, mode) })
 }
 
-func renameat(olddirfd int, oldpath string, newdirfd int, newpath string) error {
-	return ignoreEINTR(func() error { return unix.Renameat(olddirfd, oldpath, newdirfd, newpath) })
-}
-
 func linkat(olddirfd int, oldpath string, newdirfd int, newpath string, flags int) error {
 	return ignoreEINTR(func() error { return unix.Linkat(olddirfd, oldpath, newdirfd, newpath, flags) })
 }

--- a/internal/sandbox/tarfs/dir.go
+++ b/internal/sandbox/tarfs/dir.go
@@ -281,7 +281,7 @@ func (*openDir) Mkdir(string, fs.FileMode) error { return sandbox.EROFS }
 
 func (*openDir) Rmdir(string) error { return sandbox.EROFS }
 
-func (*openDir) Rename(string, sandbox.File, string) error { return sandbox.EROFS }
+func (*openDir) Rename(string, sandbox.File, string, sandbox.RenameFlags) error { return sandbox.EROFS }
 
 func (*openDir) Link(string, sandbox.File, string, sandbox.LookupFlags) error { return sandbox.EROFS }
 

--- a/internal/sandbox/tarfs/tarfs.go
+++ b/internal/sandbox/tarfs/tarfs.go
@@ -215,44 +215,78 @@ func makePath(files map[string]fileEntry, name string, modTime time.Time, file f
 
 type readOnlyFile struct{}
 
-func (readOnlyFile) Fd() uintptr { return ^uintptr(0) }
+func (readOnlyFile) Fd() uintptr {
+	return ^uintptr(0)
+}
 
-func (readOnlyFile) Writev([][]byte) (int, error) { return 0, sandbox.EBADF }
+func (readOnlyFile) Writev([][]byte) (int, error) {
+	return 0, sandbox.EBADF
+}
 
-func (readOnlyFile) Pwritev([][]byte, int64) (int, error) { return 0, sandbox.EBADF }
+func (readOnlyFile) Pwritev([][]byte, int64) (int, error) {
+	return 0, sandbox.EBADF
+}
 
-func (readOnlyFile) Allocate(int64, int64) error { return sandbox.EBADF }
+func (readOnlyFile) Allocate(int64, int64) error {
+	return sandbox.EBADF
+}
 
-func (readOnlyFile) Truncate(int64) error { return sandbox.EBADF }
+func (readOnlyFile) Truncate(int64) error {
+	return sandbox.EBADF
+}
 
-func (readOnlyFile) Sync() error { return nil }
+func (readOnlyFile) Sync() error {
+	return nil
+}
 
-func (readOnlyFile) Datasync() error { return nil }
+func (readOnlyFile) Datasync() error {
+	return nil
+}
 
-func (readOnlyFile) Flags() (sandbox.OpenFlags, error) { return 0, nil }
+func (readOnlyFile) Flags() (sandbox.OpenFlags, error) {
+	return 0, nil
+}
 
-func (readOnlyFile) SetFlags(sandbox.OpenFlags) error { return sandbox.EINVAL }
+func (readOnlyFile) SetFlags(sandbox.OpenFlags) error {
+	return sandbox.EINVAL
+}
 
 func (readOnlyFile) Chtimes(string, [2]sandbox.Timespec, sandbox.LookupFlags) error {
 	return sandbox.EPERM
 }
 
-type leafFile struct{ readOnlyFile }
+type leafFile struct {
+	readOnlyFile
+}
 
 func (leafFile) Open(string, sandbox.OpenFlags, fs.FileMode) (sandbox.File, error) {
 	return nil, sandbox.ENOTDIR
 }
 
-func (leafFile) ReadDirent([]byte) (int, error) { return 0, sandbox.ENOTDIR }
+func (leafFile) ReadDirent([]byte) (int, error) {
+	return 0, sandbox.ENOTDIR
+}
 
-func (leafFile) Mkdir(string, fs.FileMode) error { return sandbox.ENOTDIR }
+func (leafFile) Mkdir(string, fs.FileMode) error {
+	return sandbox.ENOTDIR
+}
 
-func (leafFile) Rmdir(string) error { return sandbox.ENOTDIR }
+func (leafFile) Rmdir(string) error {
+	return sandbox.ENOTDIR
+}
 
-func (leafFile) Rename(string, sandbox.File, string) error { return sandbox.ENOTDIR }
+func (leafFile) Rename(string, sandbox.File, string, sandbox.RenameFlags) error {
+	return sandbox.ENOTDIR
+}
 
-func (leafFile) Link(string, sandbox.File, string, sandbox.LookupFlags) error { return sandbox.ENOTDIR }
+func (leafFile) Link(string, sandbox.File, string, sandbox.LookupFlags) error {
+	return sandbox.ENOTDIR
+}
 
-func (leafFile) Symlink(string, string) error { return sandbox.ENOTDIR }
+func (leafFile) Symlink(string, string) error {
+	return sandbox.ENOTDIR
+}
 
-func (leafFile) Unlink(string) error { return sandbox.ENOTDIR }
+func (leafFile) Unlink(string) error {
+	return sandbox.ENOTDIR
+}

--- a/internal/sandbox/wasi.go
+++ b/internal/sandbox/wasi.go
@@ -378,7 +378,7 @@ func (f *wasiFile) PathRename(ctx context.Context, oldPath string, newDir anyFil
 	if !ok {
 		return wasi.EXDEV
 	}
-	return wasi.MakeErrno(f.file.Rename(oldPath, d.file, newPath))
+	return wasi.MakeErrno(f.file.Rename(oldPath, d.file, newPath, 0))
 }
 
 func (f *wasiFile) PathSymlink(ctx context.Context, oldPath string, newPath string) wasi.Errno {


### PR DESCRIPTION
This PR adds support for passing flags to `sandbox.File.Rename`, which is necessary to implement a copy-on-write file system: RENAME_NOREPLACE ensures that we can coordinate concurrent operations creating files in the write layer of the file system.