### PR TITLE
sandbox: add File.CopyFileRange

### DIFF
--- a/internal/sandbox/ocifs/file.go
+++ b/internal/sandbox/ocifs/file.go
@@ -331,6 +331,15 @@ func (f *file) Pwritev(iovs [][]byte, offset int64) (int, error) {
 	return 0, sandbox.EBADF
 }
 
+func (f *file) CopyFileRange(srcOffset int64, dst sandbox.File, dstOffset int64, length int) (int, error) {
+	l := f.ref()
+	if l == nil {
+		return 0, sandbox.EBADF
+	}
+	defer unref(l)
+	return l.files[0].CopyFileRange(srcOffset, dst, dstOffset, length)
+}
+
 func (f *file) Seek(offset int64, whence int) (int64, error) {
 	l := f.ref()
 	if l == nil {

--- a/internal/sandbox/sandboxtest/fs.go
+++ b/internal/sandbox/sandboxtest/fs.go
@@ -47,6 +47,7 @@ func TestFileSystem(t *testing.T, makeFS func(*testing.T) sandbox.FileSystem) {
 	t.Run("Rename", func(t *testing.T) { fsTestRename.run(t, makeFS) })
 	t.Run("Mkdir", func(t *testing.T) { fsTestMkdir.run(t, makeFS) })
 	t.Run("Rmdir", func(t *testing.T) { fsTestRmdir.run(t, makeFS) })
+	t.Run("CopyFile", func(t *testing.T) { fsTestCopyFile.run(t, makeFS) })
 }
 
 type fsTestSuite map[string]func(*testing.T, sandbox.FileSystem)

--- a/internal/sandbox/sandboxtest/fs_copy_file.go
+++ b/internal/sandbox/sandboxtest/fs_copy_file.go
@@ -1,0 +1,32 @@
+package sandboxtest
+
+import (
+	"crypto/rand"
+	"io"
+	"testing"
+
+	"github.com/stealthrocket/timecraft/internal/assert"
+	"github.com/stealthrocket/timecraft/internal/sandbox"
+)
+
+var fsTestCopyFile = fsTestSuite{
+	"copying a file which does not exist errors with ENOENT": func(t *testing.T, fsys sandbox.FileSystem) {
+		err := sandbox.CopyFile(fsys, "src", "dst")
+		assert.Error(t, err, sandbox.ENOENT)
+
+		_, err = sandbox.Stat(fsys, "dst")
+		assert.Error(t, err, sandbox.ENOENT)
+	},
+
+	"files can be copied on a file system": func(t *testing.T, fsys sandbox.FileSystem) {
+		content := make([]byte, 1e6)
+		_, err := io.ReadFull(rand.Reader, content)
+		assert.OK(t, err)
+		assert.OK(t, sandbox.WriteFile(fsys, "src", content, 0644))
+		assert.OK(t, sandbox.CopyFile(fsys, "src", "dst"))
+
+		b, err := sandbox.ReadFile(fsys, "dst", 0)
+		assert.OK(t, err)
+		assert.Equal(t, string(b), string(content))
+	},
+}

--- a/internal/sandbox/syscall_darwin.go
+++ b/internal/sandbox/syscall_darwin.go
@@ -343,6 +343,10 @@ func pwritev(fd int, iovs [][]byte, off int64) (int, error) {
 	return wn, nil
 }
 
+func copyFileRange(srcfd int, srcoff int64, dstfd int, dstoff int64, length int) (int, error) {
+	return -1, ENOSYS
+}
+
 func renameat(olddirfd int, oldpath string, newdirfd int, newpath string, flags int) error {
 	oldpathptr, err := unix.BytePtrFromString(oldpath)
 	if err != nil {

--- a/internal/sandbox/syscall_linux.go
+++ b/internal/sandbox/syscall_linux.go
@@ -117,6 +117,22 @@ func pwritev(fd int, iovs [][]byte, offset int64) (int, error) {
 	return handleEINTR(func() (int, error) { return unix.Pwritev(fd, iovs, offset) })
 }
 
+func copyFileRange(srcfd int, srcoff int64, dstfd int, dstoff int64, length int) (int, error) {
+	copied := 0
+	for copied < length {
+		n, err := unix.CopyFileRange(srcfd, &srcoff, dstfd, &dstoff, length-copied, 0)
+		if n > 0 {
+			copied += n
+		}
+		if err != nil && err != unix.EINTR {
+			return copied, err
+		} else if n == 0 {
+			break
+		}
+	}
+	return copied, nil
+}
+
 func renameat(olddirfd int, oldpath string, newdirfd int, newpath string, flags int) error {
 	return ignoreEINTR(func() error { return unix.Renameat2(olddirfd, oldpath, newdirfd, newpath, uint(flags)) })
 }

--- a/internal/sandbox/tarfs/dir.go
+++ b/internal/sandbox/tarfs/dir.go
@@ -292,3 +292,5 @@ func (*openDir) Unlink(string) error { return sandbox.EROFS }
 func (*openDir) Readv([][]byte) (int, error) { return 0, sandbox.EISDIR }
 
 func (*openDir) Preadv([][]byte, int64) (int, error) { return 0, sandbox.EISDIR }
+
+func (*openDir) CopyFileRange(int64, sandbox.File, int64, int) (int, error) { return 0, sandbox.EISDIR }

--- a/internal/sandbox/tarfs/file_linux.go
+++ b/internal/sandbox/tarfs/file_linux.go
@@ -1,0 +1,19 @@
+package tarfs
+
+import "golang.org/x/sys/unix"
+
+func copyFileRange(srcfd int, srcoff int64, dstfd int, dstoff int64, length int) (int, error) {
+	copied := 0
+	for copied < length {
+		n, err := unix.CopyFileRange(srcfd, &srcoff, dstfd, &dstoff, length-copied, 0)
+		if n > 0 {
+			copied += n
+		}
+		if err != nil && err != unix.EINTR {
+			return copied, err
+		} else if n == 0 {
+			break
+		}
+	}
+	return copied, nil
+}

--- a/internal/sandbox/tarfs/file_other.go
+++ b/internal/sandbox/tarfs/file_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package tarfs
+
+import "github.com/stealthrocket/timecraft/internal/sandbox"
+
+func copyFileRange(srcfd int, srcoff int64, dstfd int, dstoff int64, length int) (int, error) {
+	return -1, sandbox.ENOSYS
+}


### PR DESCRIPTION
Another step towards supporting copy-on-write, this PR adds a new `CopyFileRange` to the `File` interface to allow an efficient copy of files that are migrated to the write layer of the file system.