### PR TITLE
sandbox: add overlay file system

### DIFF
--- a/internal/sandbox/fs.go
+++ b/internal/sandbox/fs.go
@@ -133,7 +133,7 @@ func ReadFile(fsys FileSystem, name string, flags LookupFlags) ([]byte, error) {
 
 // WriteFile writes a file on a file system.
 func WriteFile(fsys FileSystem, name string, data []byte, mode fs.FileMode) error {
-	f, err := fsys.Open(name, O_CREAT|O_WRONLY|O_TRUNC|O_EXCL, mode)
+	f, err := fsys.Open(name, O_CREAT|O_WRONLY|O_TRUNC, mode)
 	if err != nil {
 		return &fs.PathError{Op: "write", Path: name, Err: err}
 	}

--- a/internal/sandbox/ocifs/dir.go
+++ b/internal/sandbox/ocifs/dir.go
@@ -120,6 +120,9 @@ func (d *dirbuf) readDirent(buf []byte, files []sandbox.File) (int, error) {
 		dirent := &d.entries[d.index]
 		wn := sandbox.WriteDirent(buf[n:], dirent.typ, dirent.ino, d.offset, dirent.name)
 		n += wn
+		if wn < sandbox.SizeOfDirent(len(dirent.name)) {
+			break
+		}
 		d.index++
 		d.offset += uint64(wn)
 	}

--- a/internal/sandbox/ocifs/file.go
+++ b/internal/sandbox/ocifs/file.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/stealthrocket/timecraft/internal/sandbox"
-	"github.com/stealthrocket/timecraft/internal/sandbox/fspath"
 )
 
 const (
@@ -54,128 +53,110 @@ func (f *file) Close() error {
 }
 
 func (f *file) openSelf() (sandbox.File, error) {
-	l := f.ref()
-	if l == nil {
-		return nil, sandbox.EBADF
-	}
-	defer unref(l)
-	return newFile(l), nil
+	return withLayers2(f, func(l *fileLayers) (sandbox.File, error) {
+		return newFile(l), nil
+	})
 }
 
 func (f *file) openParent() (sandbox.File, error) {
-	l := f.ref()
-	if l == nil {
-		return nil, sandbox.EBADF
-	}
-	defer unref(l)
-
-	p := l.parent
-	if p == nil { // already at the root?
-		p = l
-	}
-
-	return newFile(p), nil
+	return withLayers2(f, func(l *fileLayers) (sandbox.File, error) {
+		if l.parent != nil {
+			l = l.parent
+		}
+		return newFile(l), nil
+	})
 }
 
 func (f *file) openRoot() (sandbox.File, error) {
-	l := f.ref()
-	if l == nil {
-		return nil, sandbox.EBADF
-	}
-	defer unref(l)
-
-	for l.parent != nil { // walk up to the root
-		l = l.parent
-	}
-
-	return newFile(l), nil
+	return withLayers2(f, func(l *fileLayers) (sandbox.File, error) {
+		for l.parent != nil { // walk up to the root
+			l = l.parent
+		}
+		return newFile(l), nil
+	})
 }
 
 func (f *file) openFile(name string, flags sandbox.OpenFlags, mode fs.FileMode) (sandbox.File, error) {
-	l := f.ref()
-	if l == nil {
-		return nil, sandbox.EBADF
-	}
-	defer unref(l)
+	return withLayers2(f, func(l *fileLayers) (sandbox.File, error) {
+		var files []sandbox.File
+		defer func() {
+			closeFiles(files) // only closed on error or panic
+		}()
 
-	var files []sandbox.File
-	defer func() {
-		closeFiles(files) // only closed on error or panic
-	}()
+		whiteout := whiteoutPrefix + name
 
-	whiteout := whiteoutPrefix + name
-
-	for _, file := range l.files {
-		f, err := file.Open(name, flags|sandbox.O_NOFOLLOW, mode)
-		if err != nil {
-			if errors.Is(err, sandbox.ELOOP) && len(files) > 0 {
-				// The file was a symbolic link and it is present in a lower
-				// layer which indicates that it masks all potential directories
-				// below, and it is masked by the upper directory layers.
-				break
-			}
-			if errors.Is(err, sandbox.ENOTDIR) && ((flags & sandbox.O_NOFOLLOW) != 0) && len(files) > 0 {
-				// The program attempted to open a directory but a lower layer
-				// had a file of a different type with the same name. This is
-				// an indicator that we must stop merging layers here because
-				// the file masks its lower layers and it is masked by the
-				// directories at the upper layers.
-				break
-			}
-			if !errors.Is(err, sandbox.ENOENT) {
-				// Errors other than ENOENT indicate that something went wrong
-				// and we must abort path resolution because we might otherwise
-				// create an unconsistent view of the file system.
-				return nil, err
-			}
-		} else {
-			s, err := f.Stat("", sandbox.AT_SYMLINK_NOFOLLOW)
+		for _, file := range l.files {
+			f, err := file.Open(name, flags|sandbox.O_NOFOLLOW, mode)
 			if err != nil {
-				f.Close()
+				if errors.Is(err, sandbox.ELOOP) && len(files) > 0 {
+					// The file was a symbolic link and it is present in a lower
+					// layer which indicates that it masks all potential directories
+					// below, and it is masked by the upper directory layers.
+					break
+				}
+				if errors.Is(err, sandbox.ENOTDIR) && ((flags & sandbox.O_NOFOLLOW) != 0) && len(files) > 0 {
+					// The program attempted to open a directory but a lower layer
+					// had a file of a different type with the same name. This is
+					// an indicator that we must stop merging layers here because
+					// the file masks its lower layers and it is masked by the
+					// directories at the upper layers.
+					break
+				}
+				if !errors.Is(err, sandbox.ENOENT) {
+					// Errors other than ENOENT indicate that something went wrong
+					// and we must abort path resolution because we might otherwise
+					// create an unconsistent view of the file system.
+					return nil, err
+				}
+			} else {
+				s, err := f.Stat("", sandbox.AT_SYMLINK_NOFOLLOW)
+				if err != nil {
+					f.Close()
+					return nil, err
+				}
+
+				isDir := s.Mode.IsDir()
+				if !isDir && len(files) > 0 {
+					// Files that are not directories in lower layers cannot be
+					// merged into the upper layers, they mask the layers below them
+					// while also being masked by the directories above, so we stop
+					// merging the views at this stage.
+					f.Close()
+					break
+				}
+
+				files = append(files, f)
+
+				if !isDir {
+					// This branch is taken on the first iteration, if the file is
+					// not a directory it masks the underlying layers so we stop
+					// merging layers here.
+					break
+				}
+			}
+
+			// This point is reached if the file was successfully opened, or if it
+			// did not exist. We must check for whiteout files to determine whether
+			// we must stop merging layers.
+			if wh, err := hasWhiteout(file, whiteout); err != nil {
 				return nil, err
-			}
-
-			isDir := s.Mode.IsDir()
-			if !isDir && len(files) > 0 {
-				// Files that are not directories in lower layers cannot be
-				// merged into the upper layers, they mask the layers below them
-				// while also being masked by the directories above, so we stop
-				// merging the views at this stage.
-				f.Close()
-				break
-			}
-
-			files = append(files, f)
-
-			if !isDir {
-				// This branch is taken on the first iteration, if the file is
-				// not a directory it masks the underlying layers so we stop
-				// merging layers here.
+			} else if wh {
 				break
 			}
 		}
 
-		// This point is reached if the file was successfully opened, or if it
-		// did not exist. We must check for whiteout files to determine whether
-		// we must stop merging layers.
-		if wh, err := hasWhiteout(file, whiteout); err != nil {
-			return nil, err
-		} else if wh {
-			break
+		if len(files) == 0 {
+			// We could not find any file matching the name in any of the layers,
+			// this indicates that the file does not exist.
+			return nil, sandbox.ENOENT
 		}
-	}
 
-	if len(files) == 0 {
-		// We could not find any file matching the name in any of the layers,
-		// this indicates that the file does not exist.
-		return nil, sandbox.ENOENT
-	}
-
-	open := newFile(&fileLayers{parent: l, files: files})
-	// The new fileLayers value owns a reference to its parent
-	ref(open.layers.parent)
-	files = nil // prevents the defer from closing the files
-	return open, nil
+		open := newFile(&fileLayers{parent: l, files: files})
+		// The new fileLayers value owns a reference to its parent
+		ref(open.layers.parent)
+		files = nil // prevents the defer from closing the files
+		return open, nil
+	})
 }
 
 func hasWhiteout(file sandbox.File, whiteout string) (has bool, err error) {
@@ -194,60 +175,30 @@ func hasWhiteout(file sandbox.File, whiteout string) (has bool, err error) {
 	return false, nil
 }
 
-func (f *file) open(name string, flags sandbox.OpenFlags, mode fs.FileMode) (sandbox.File, error) {
-	switch name {
-	case ".":
-		return f.openSelf()
-	case "..":
-		return f.openParent()
-	default:
-		return f.openFile(name, flags, mode)
-	}
-}
-
 func (f *file) Open(name string, flags sandbox.OpenFlags, mode fs.FileMode) (sandbox.File, error) {
 	const unsupportedFlags = sandbox.O_CREAT |
 		sandbox.O_APPEND |
 		sandbox.O_RDWR |
 		sandbox.O_WRONLY
-
-	if ((flags & unsupportedFlags) != 0) || mode != 0 || name == "" {
-		return nil, sandbox.EINVAL
-	}
-	if fspath.IsRoot(name) {
-		return f.openRoot()
-	}
-	if fspath.HasTrailingSlash(name) {
-		flags |= sandbox.O_DIRECTORY
-	}
-	return sandbox.ResolvePath(f, name, flags.LookupFlags(), func(at *file, name string) (sandbox.File, error) {
-		return at.open(name, flags, mode)
-	})
+	return sandbox.FileOpen(f, name, flags, ^unsupportedFlags, mode,
+		(*file).openRoot,
+		(*file).openSelf,
+		(*file).openParent,
+		(*file).openFile,
+	)
 }
 
 func (f *file) Stat(name string, flags sandbox.LookupFlags) (sandbox.FileInfo, error) {
-	l := f.ref()
-	if l == nil {
-		return sandbox.FileInfo{}, sandbox.EBADF
-	}
-	defer unref(l)
-
-	return sandbox.ResolvePath(f, name, flags, func(at *file, name string) (sandbox.FileInfo, error) {
-		l := at.ref()
-		defer unref(l)
-
+	return sandbox.FileStat(f, name, flags, func(at *file, name string) (sandbox.FileInfo, error) {
 		whiteout := whiteoutPrefix + name
 
-		for _, file := range l.files {
+		for _, file := range at.layers.files {
 			info, err := file.Stat(name, sandbox.AT_SYMLINK_NOFOLLOW)
 			if err != nil {
 				if !errors.Is(err, sandbox.ENOENT) {
 					return sandbox.FileInfo{}, err
 				}
 			} else {
-				if info.Mode.Type() == fs.ModeSymlink && ((flags & sandbox.AT_SYMLINK_NOFOLLOW) == 0) {
-					err = sandbox.ELOOP
-				}
 				return info, err
 			}
 
@@ -263,19 +214,10 @@ func (f *file) Stat(name string, flags sandbox.LookupFlags) (sandbox.FileInfo, e
 }
 
 func (f *file) Readlink(name string, buf []byte) (int, error) {
-	l := f.ref()
-	if l == nil {
-		return 0, sandbox.EBADF
-	}
-	defer unref(l)
-
-	return sandbox.ResolvePath(f, name, sandbox.AT_SYMLINK_NOFOLLOW, func(at *file, name string) (int, error) {
-		l := at.ref()
-		defer unref(l)
-
+	return sandbox.FileReadlink(f, name, func(at *file, name string) (int, error) {
 		whiteout := whiteoutPrefix + name
 
-		for _, file := range l.files {
+		for _, file := range at.layers.files {
 			n, err := file.Readlink(name, buf)
 			if err != nil {
 				if !errors.Is(err, sandbox.ENOENT) {
@@ -306,12 +248,9 @@ func (f *file) Fd() uintptr {
 }
 
 func (f *file) Readv(iovs [][]byte) (int, error) {
-	l := f.ref()
-	if l == nil {
-		return 0, sandbox.EBADF
-	}
-	defer unref(l)
-	return l.files[0].Readv(iovs)
+	return withLayers2(f, func(l *fileLayers) (int, error) {
+		return l.files[0].Readv(iovs)
+	})
 }
 
 func (f *file) Writev(iovs [][]byte) (int, error) {
@@ -319,47 +258,36 @@ func (f *file) Writev(iovs [][]byte) (int, error) {
 }
 
 func (f *file) Preadv(iovs [][]byte, offset int64) (int, error) {
-	l := f.ref()
-	if l == nil {
-		return 0, sandbox.EBADF
-	}
-	defer unref(l)
-	return l.files[0].Preadv(iovs, offset)
+	return withLayers2(f, func(l *fileLayers) (int, error) {
+		return l.files[0].Preadv(iovs, offset)
+	})
 }
 
 func (f *file) Pwritev(iovs [][]byte, offset int64) (int, error) {
 	return 0, sandbox.EBADF
 }
 
-func (f *file) CopyFileRange(srcOffset int64, dst sandbox.File, dstOffset int64, length int) (int, error) {
-	l := f.ref()
-	if l == nil {
-		return 0, sandbox.EBADF
-	}
-	defer unref(l)
-	return l.files[0].CopyFileRange(srcOffset, dst, dstOffset, length)
+func (f *file) CopyRange(srcOffset int64, dst sandbox.File, dstOffset int64, length int) (int, error) {
+	return withLayers2(f, func(l *fileLayers) (int, error) {
+		return l.files[0].CopyRange(srcOffset, dst, dstOffset, length)
+	})
 }
 
 func (f *file) Seek(offset int64, whence int) (int64, error) {
-	l := f.ref()
-	if l == nil {
-		return 0, sandbox.EBADF
-	}
-	defer unref(l)
+	return withLayers2(f, func(l *fileLayers) (int64, error) {
+		f.mutex.Lock()
+		d := f.dirbuf
+		f.mutex.Unlock()
 
-	f.mutex.Lock()
-	d := f.dirbuf
-	f.mutex.Unlock()
-
-	if d != nil {
-		if offset != 0 || whence != 0 {
-			return 0, sandbox.EINVAL
+		if d != nil {
+			if offset != 0 || whence != 0 {
+				return 0, sandbox.EINVAL
+			}
+			d.reset()
+			return 0, nil
 		}
-		d.reset()
-		return 0, nil
-	}
-
-	return l.files[0].Seek(offset, whence)
+		return l.files[0].Seek(offset, whence)
+	})
 }
 
 func (f *file) Allocate(int64, int64) error {
@@ -387,20 +315,15 @@ func (f *file) SetFlags(sandbox.OpenFlags) error {
 }
 
 func (f *file) ReadDirent(buf []byte) (int, error) {
-	l := f.ref()
-	if l == nil {
-		return 0, sandbox.EBADF
-	}
-	defer unref(l)
-
-	f.mutex.Lock()
-	if f.dirbuf == nil {
-		f.dirbuf = &dirbuf{index: -1}
-	}
-	d := f.dirbuf
-	f.mutex.Unlock()
-
-	return d.readDirent(buf, l.files)
+	return withLayers2(f, func(l *fileLayers) (int, error) {
+		f.mutex.Lock()
+		if f.dirbuf == nil {
+			f.dirbuf = &dirbuf{index: -1}
+		}
+		d := f.dirbuf
+		f.mutex.Unlock()
+		return d.readDirent(buf, l.files)
+	})
 }
 
 func (f *file) Chtimes(string, [2]sandbox.Timespec, sandbox.LookupFlags) error {
@@ -432,17 +355,33 @@ func (f *file) Unlink(string) error {
 }
 
 func (f *file) expectDirectory() error {
-	l := f.ref()
-	if l == nil {
+	return withLayers1(f, func(l *fileLayers) error {
+		info, err := l.files[0].Stat("", sandbox.AT_SYMLINK_NOFOLLOW)
+		if err != nil {
+			return err
+		}
+		if !info.Mode.IsDir() {
+			return sandbox.ENOTDIR
+		}
+		return sandbox.EROFS
+	})
+}
+
+func withLayers1(f *file, do func(*fileLayers) error) error {
+	layers := f.ref()
+	if layers == nil {
 		return sandbox.EBADF
 	}
-	defer unref(l)
-	info, err := l.files[0].Stat("", sandbox.AT_SYMLINK_NOFOLLOW)
-	if err != nil {
-		return err
+	defer unref(layers)
+	return do(f.layers)
+}
+
+func withLayers2[R any](f *file, do func(*fileLayers) (R, error)) (R, error) {
+	layers := f.ref()
+	if layers == nil {
+		var zero R
+		return zero, sandbox.EBADF
 	}
-	if !info.Mode.IsDir() {
-		return sandbox.ENOTDIR
-	}
-	return sandbox.EROFS
+	defer unref(layers)
+	return do(f.layers)
 }

--- a/internal/sandbox/overlayfs/file.go
+++ b/internal/sandbox/overlayfs/file.go
@@ -1,0 +1,451 @@
+package overlayfs
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"sync"
+
+	"github.com/stealthrocket/timecraft/internal/sandbox"
+)
+
+const (
+	whiteoutPrefix = ".wh."
+	tempFilePrefix = ".wh..tmp."
+)
+
+type file struct {
+	mutex   sync.Mutex
+	overlay *fileOverlay
+	dir     *dirOverlay
+}
+
+func newFile(overlay *fileOverlay) *file {
+	f := &file{overlay: overlay}
+	ref(overlay)
+	return f
+}
+
+func (f *file) String() string {
+	overlay := f.ref()
+	if overlay == nil {
+		return "&overlayfs.file{nil}"
+	}
+	defer unref(overlay)
+	return fmt.Sprintf("&overlayfs.file{lower:%v,upper:%v}", overlay.lower, overlay.upper)
+}
+
+func (f *file) ref() *fileOverlay {
+	f.mutex.Lock()
+	overlay := f.overlay
+	ref(overlay)
+	f.mutex.Unlock()
+	return overlay
+}
+
+func (f *file) Close() error {
+	f.mutex.Lock()
+	overlay := f.overlay
+	f.overlay = nil
+	f.mutex.Unlock()
+	unref(overlay)
+	return nil
+}
+
+func (f *file) openSelf() (sandbox.File, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (sandbox.File, error) {
+		return newFile(overlay), nil
+	})
+}
+
+func (f *file) openParent() (sandbox.File, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (sandbox.File, error) {
+		if overlay.parent != nil {
+			overlay = overlay.parent
+		}
+		return newFile(overlay), nil
+	})
+}
+
+func (f *file) openRoot() (sandbox.File, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (sandbox.File, error) {
+		for overlay.parent != nil {
+			overlay = overlay.parent
+		}
+		return newFile(overlay), nil
+	})
+}
+
+func (f *file) openFile(name string, flags sandbox.OpenFlags, mode fs.FileMode) (sandbox.File, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (sandbox.File, error) {
+		const writeFlags = sandbox.O_CREAT |
+			sandbox.O_APPEND |
+			sandbox.O_RDWR |
+			sandbox.O_WRONLY |
+			sandbox.O_TRUNC
+
+		if overlay.lower != nil {
+			// When the file is going to be created, we must ensure that the
+			// path exists in the upper layer if it exists in the lower layer.
+			if (flags & writeFlags) != 0 {
+				// If the file is to be created exclusively, we must check that
+				// it does not exist in the lower layer, otherwise it might be
+				// created in the upper loyer because it does not exist there.
+				if (flags & sandbox.O_EXCL) != 0 {
+					if ok, err := exists(overlay.lower, name); err != nil {
+						return nil, err
+					} else if ok {
+						return nil, sandbox.EEXIST
+					}
+				}
+				if err := overlay.makePath(); err != nil {
+					return nil, err
+				}
+			}
+			// When the file is open for writing, we need to move it to the
+			// upper layer to allow it to receive writes. However, if the file
+			// is to be truncated, we don't need to create its content and can
+			// simply let the upper layer add an empty file.
+			if ((flags & writeFlags) != 0) && ((flags & sandbox.O_TRUNC) == 0) {
+				if err := overlay.makeFile(name); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		var lower sandbox.File
+		var upper sandbox.File
+		var err error
+
+		defer func() {
+			closeIfNotNil(lower)
+			closeIfNotNil(upper)
+		}()
+
+		if overlay.upper != nil {
+			upper, err = overlay.upper.Open(name, flags, mode)
+			if err != nil {
+				if !errors.Is(err, sandbox.ENOENT) {
+					return nil, err
+				}
+			}
+		}
+
+		if overlay.lower != nil {
+			const readOnlyFlags = sandbox.O_DIRECTORY | sandbox.O_NOFOLLOW | sandbox.O_RDONLY
+			lower, err = overlay.lower.Open(name, flags&readOnlyFlags, 0)
+			if err != nil {
+				if !errors.Is(err, sandbox.ENOENT) && upper == nil {
+					return nil, err
+				}
+			}
+		}
+
+		if lower == nil && upper == nil {
+			return nil, sandbox.ENOENT
+		}
+
+		open := newFile(newFileOverlay(overlay, lower, upper, name))
+		lower = nil
+		upper = nil
+		return open, nil
+	})
+}
+
+func lstat(file sandbox.File, name string) (sandbox.FileInfo, error) {
+	return file.Stat(name, sandbox.AT_SYMLINK_NOFOLLOW)
+}
+
+func exists(file sandbox.File, name string) (has bool, err error) {
+	_, err = lstat(file, name)
+	if err == nil {
+		return true, nil
+	} else if !errors.Is(err, sandbox.ENOENT) {
+		return false, err
+	} else {
+		return false, nil
+	}
+}
+
+func (f *file) Open(name string, flags sandbox.OpenFlags, mode fs.FileMode) (sandbox.File, error) {
+	return sandbox.FileOpen(f, name, flags, ^sandbox.OpenFlags(0), mode,
+		(*file).openRoot,
+		(*file).openSelf,
+		(*file).openParent,
+		(*file).openFile,
+	)
+}
+
+func (f *file) Stat(name string, flags sandbox.LookupFlags) (sandbox.FileInfo, error) {
+	return sandbox.FileStat(f, name, flags, func(at *file, name string) (sandbox.FileInfo, error) {
+		return withOverlay2(at, func(overlay *fileOverlay) (sandbox.FileInfo, error) {
+			whiteout := whiteoutPrefix + name
+
+			for _, file := range overlay.files() {
+				info, err := file.Stat(name, sandbox.AT_SYMLINK_NOFOLLOW)
+				if err != nil {
+					if !errors.Is(err, sandbox.ENOENT) {
+						return info, err
+					}
+				} else {
+					// TOOD: directories in the upper layer cannot be made
+					// unwritable at this time, so we always set their write
+					// permissions to represent this limitation.
+					//
+					// See (*fileOverlay).makePath for more details.
+					if info.Mode.Type() == fs.ModeDir {
+						info.Mode = fs.ModeDir | 0755
+					}
+					return info, nil
+				}
+
+				if ok, err := exists(file, whiteout); err != nil {
+					return sandbox.FileInfo{}, err
+				} else if ok {
+					break
+				}
+			}
+
+			return sandbox.FileInfo{}, sandbox.ENOENT
+		})
+	})
+}
+
+func (f *file) Readlink(name string, buf []byte) (int, error) {
+	return sandbox.FileReadlink(f, name, func(at *file, name string) (int, error) {
+		return withOverlay2(at, func(overlay *fileOverlay) (int, error) {
+			whiteout := whiteoutPrefix + name
+
+			for _, file := range overlay.files() {
+				n, err := file.Readlink(name, buf)
+				if err != nil {
+					if !errors.Is(err, sandbox.ENOENT) {
+						return 0, err
+					}
+				} else {
+					return n, nil
+				}
+
+				if ok, err := exists(file, whiteout); err != nil {
+					return 0, err
+				} else if ok {
+					break
+				}
+			}
+
+			return 0, sandbox.ENOENT
+		})
+	})
+}
+
+func (f *file) Fd() uintptr {
+	overlay := f.ref()
+	if overlay == nil {
+		return ^uintptr(0)
+	}
+	defer unref(overlay)
+	return overlay.lower.Fd()
+}
+
+func (f *file) Readv(iovs [][]byte) (int, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (int, error) {
+		return overlay.file().Readv(iovs)
+	})
+}
+
+func (f *file) Writev(iovs [][]byte) (int, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (int, error) {
+		// This condition will be true when the file was not opened with a write
+		// flag like O_WRONLY or O_RDWR.
+		if overlay.upper == nil {
+			return 0, sandbox.EBADF
+		}
+		return overlay.upper.Writev(iovs)
+	})
+}
+
+func (f *file) Preadv(iovs [][]byte, offset int64) (int, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (int, error) {
+		return overlay.file().Preadv(iovs, offset)
+	})
+}
+
+func (f *file) Pwritev(iovs [][]byte, offset int64) (int, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (int, error) {
+		// This condition will be true when the file was not opened with a write
+		// flag like O_WRONLY or O_RDWR.
+		if overlay.upper == nil {
+			return 0, sandbox.EBADF
+		}
+		return overlay.upper.Pwritev(iovs, offset)
+	})
+}
+
+func (f *file) CopyRange(srcOffset int64, dst sandbox.File, dstOffset int64, length int) (int, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (int, error) {
+		return overlay.file().CopyRange(srcOffset, dst, dstOffset, length)
+	})
+}
+
+func (f *file) Seek(offset int64, whence int) (int64, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (int64, error) {
+		f.mutex.Lock()
+		dir := f.dir
+		f.mutex.Unlock()
+
+		if dir != nil {
+			if offset != 0 || whence != 0 {
+				return 0, sandbox.EINVAL
+			}
+			dir.reset()
+			return 0, nil
+		}
+
+		return overlay.file().Seek(offset, whence)
+	})
+}
+
+func (f *file) Allocate(int64, int64) error {
+	return withOverlay1(f, func(overlay *fileOverlay) error {
+		return sandbox.ENOSYS
+	})
+}
+
+func (f *file) Truncate(int64) error {
+	return withOverlay1(f, func(overlay *fileOverlay) error {
+		return sandbox.ENOSYS
+	})
+}
+
+func (f *file) Sync() error {
+	return withOverlay1(f, func(overlay *fileOverlay) error {
+		return sandbox.ENOSYS
+	})
+}
+
+func (f *file) Datasync() error {
+	return withOverlay1(f, func(overlay *fileOverlay) error {
+		return sandbox.ENOSYS
+	})
+}
+
+func (f *file) Flags() (sandbox.OpenFlags, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (sandbox.OpenFlags, error) {
+		return overlay.file().Flags()
+	})
+}
+
+func (f *file) SetFlags(sandbox.OpenFlags) error {
+	return withOverlay1(f, func(overlay *fileOverlay) error {
+		return sandbox.ENOSYS
+	})
+}
+
+func (f *file) ReadDirent(buf []byte) (int, error) {
+	return withOverlay2(f, func(overlay *fileOverlay) (int, error) {
+		lower := overlay.lower
+		upper := overlay.upper
+		switch {
+		case lower == nil:
+			return upper.ReadDirent(buf)
+		case upper == nil:
+			return lower.ReadDirent(buf)
+		default:
+			f.mutex.Lock()
+			if f.dir == nil {
+				f.dir = newDirOverlay()
+			}
+			f.mutex.Unlock()
+			return f.dir.readDirent(lower, upper, buf)
+		}
+	})
+}
+
+func (f *file) Chtimes(name string, times [2]sandbox.Timespec, flags sandbox.LookupFlags) error {
+	return resolvePath1(f, name, flags, func(upper sandbox.File, name string) error {
+		return upper.Chtimes(name, times, flags)
+	})
+}
+
+func (f *file) Mkdir(name string, perm fs.FileMode) error {
+	return resolvePath1(f, name, sandbox.AT_SYMLINK_NOFOLLOW, func(upper sandbox.File, name string) error {
+		return upper.Mkdir(name, perm)
+	})
+}
+
+func (f *file) Rmdir(name string) error {
+	return resolvePath1(f, name, sandbox.AT_SYMLINK_NOFOLLOW, func(upper sandbox.File, name string) error {
+		return upper.Rmdir(name)
+	})
+}
+
+func (f1 *file) Rename(oldName string, newFile sandbox.File, newName string, flags sandbox.RenameFlags) error {
+	f2, ok := newFile.(*file)
+	if !ok {
+		return sandbox.EXDEV
+	}
+	const lookup = sandbox.AT_SYMLINK_NOFOLLOW
+	return resolvePath1(f1, oldName, lookup, func(upper1 sandbox.File, name1 string) error {
+		return resolvePath1(f2, newName, lookup, func(upper2 sandbox.File, name2 string) error {
+			return upper1.Rename(name1, upper2, name2, flags)
+		})
+	})
+}
+
+func (f1 *file) Link(oldName string, newFile sandbox.File, newName string, flags sandbox.LookupFlags) error {
+	f2, ok := newFile.(*file)
+	if !ok {
+		return sandbox.EXDEV
+	}
+	return resolvePath1(f1, oldName, flags, func(upper1 sandbox.File, name1 string) error {
+		return resolvePath1(f2, newName, flags, func(upper2 sandbox.File, name2 string) error {
+			return upper1.Link(name1, upper2, name2, flags)
+		})
+	})
+}
+
+func (f *file) Symlink(oldName, newName string) error {
+	return resolvePath1(f, newName, sandbox.AT_SYMLINK_NOFOLLOW, func(upper sandbox.File, name string) error {
+		return upper.Symlink(oldName, name)
+	})
+}
+
+func (f *file) Unlink(name string) error {
+	return resolvePath1(f, name, sandbox.AT_SYMLINK_NOFOLLOW, func(upper sandbox.File, name string) error {
+		return upper.Unlink(name)
+	})
+}
+
+func resolvePath1(f *file, name string, flags sandbox.LookupFlags, do func(sandbox.File, string) error) error {
+	_, err := sandbox.ResolvePath(f, name, flags, func(d *file, name string) (_ struct{}, err error) {
+		err = withOverlay1(d, func(overlay *fileOverlay) error {
+			if overlay.lower != nil {
+				if err := overlay.makePath(); err != nil {
+					return err
+				}
+			}
+			return do(overlay.upper, name)
+		})
+		return
+	})
+	return err
+}
+
+func withOverlay1(f *file, do func(*fileOverlay) error) error {
+	overlay := f.ref()
+	if overlay == nil {
+		return sandbox.EBADF
+	}
+	defer unref(overlay)
+	return do(overlay)
+}
+
+func withOverlay2[R any](f *file, do func(*fileOverlay) (R, error)) (R, error) {
+	overlay := f.ref()
+	if overlay == nil {
+		var zero R
+		return zero, sandbox.EBADF
+	}
+	defer unref(overlay)
+	return do(overlay)
+}

--- a/internal/sandbox/overlayfs/overlay.go
+++ b/internal/sandbox/overlayfs/overlay.go
@@ -1,0 +1,370 @@
+package overlayfs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/stealthrocket/timecraft/internal/sandbox"
+)
+
+type fileOverlay struct {
+	mutex  sync.Mutex
+	refc   int
+	name   string
+	lower  sandbox.File
+	upper  sandbox.File
+	parent *fileOverlay
+}
+
+func newFileOverlay(parent *fileOverlay, lower, upper sandbox.File, name string) *fileOverlay {
+	overlay := &fileOverlay{
+		name:   name,
+		lower:  lower,
+		upper:  upper,
+		parent: parent,
+	}
+	ref(parent)
+	return overlay
+}
+
+func (f *fileOverlay) files() []sandbox.File {
+	if f.lower != nil && f.upper != nil {
+		return []sandbox.File{f.upper, f.lower}
+	}
+	if f.upper != nil {
+		return []sandbox.File{f.upper}
+	}
+	if f.lower != nil {
+		return []sandbox.File{f.lower}
+	}
+	return nil
+}
+
+func (f *fileOverlay) file() sandbox.File {
+	if f.upper != nil {
+		return f.upper
+	} else {
+		return f.lower
+	}
+}
+
+func (f *fileOverlay) makeFile(name string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	lowerFile, err := f.lower.Open(name, sandbox.O_RDONLY, 0)
+	if err != nil {
+		if errors.Is(err, sandbox.ENOENT) {
+			err = nil
+		}
+		return err
+	}
+	defer lowerFile.Close()
+	lowerInfo, err := lowerFile.Stat("", 0)
+	if err != nil {
+		return err
+	}
+
+	var upperFileName string
+	var upperFile sandbox.File
+	for i := 0; ; i++ {
+		// Another concurrent operation may have attempted to create the file in
+		// the upper layer; to allow both operations to progress, we look for a
+		// unique temporary file name.
+		upperFileName = fmt.Sprintf("%s.%s.%d", tempFilePrefix, name, i)
+		upperFile, err = f.upper.Open(upperFileName, sandbox.O_CREAT|sandbox.O_EXCL|sandbox.O_WRONLY, 0)
+		if err != nil {
+			if errors.Is(err, sandbox.EEXIST) {
+				continue
+			}
+			return err
+		}
+		break
+	}
+	defer upperFile.Close()
+
+	success := false
+	defer func() {
+		if !success {
+			_ = f.upper.Unlink(upperFileName)
+		}
+	}()
+
+	if _, err := lowerFile.CopyRange(0, upperFile, 0, int(lowerInfo.Size)); err != nil {
+		return err
+	}
+
+	if err := upperFile.Rename(upperFileName, f.upper, name, sandbox.RENAME_NOREPLACE); err != nil {
+		// If the target file existed in the upper layer, it indicates that a
+		// concurrent operation also attempted to create it and succeeded before
+		// this one did. We don't need to do anything, the file exists so we can
+		// let the caller continue as if this call had successfully created it.
+		if errors.Is(err, sandbox.EEXIST) {
+			err = nil
+		}
+		return err
+	}
+
+	success = true
+	return nil
+}
+
+func (f *fileOverlay) makePath() error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	// The upper layer already exists, which means that the path to the
+	// directory is already created.
+	if f.upper != nil {
+		return nil
+	}
+
+	if f.parent != nil {
+		if err := f.parent.makePath(); err != nil {
+			return err
+		}
+	}
+
+	// TODO: we don't yet support configuring permissions on the directories
+	// that are created in the upper layer, but we don't need it for the WASI
+	// use case.
+	//
+	// Note that this is somewhat of a bug because the lower layer may have set
+	// restrictive permissions (e.g. not allowing to move files), and mirroring
+	// it to the upper layer changes that.
+	//
+	// When we address this limitation, here are a few things we need to take
+	// into account:
+	//
+	//  - We cannot simply mirror the permissions of the lower directory,
+	//    because a directory without write permission would prevent creating
+	//    other files or directories in it.
+	//
+	//  - We could emulate permissions by storing a hidden file in the directory
+	//    and implementing permission checks in user space. There are ties to
+	//    the concept of user and group that do not exist in WASI and we would
+	//    need to replicate.
+	//
+	//  - We would probably need to add a sandbox.File.Chmod method to support
+	//    configuring permissions after the directory is created.
+	//
+	//  - We might need to support configuring the directory under a different
+	//    unique and hidden name prior to moving it to the final location.
+	//
+	// When we address this issue, we should invest in extensive test suites,
+	// permission management is not for the faint of heart!
+	if err := f.parent.upper.Mkdir(f.name, 0755); err != nil {
+		if !errors.Is(err, sandbox.EEXIST) {
+			return err
+		}
+	}
+	d, err := f.parent.upper.Open(f.name, sandbox.O_DIRECTORY, 0)
+	if err != nil {
+		return err
+	}
+	f.upper = d
+	return nil
+}
+
+func (f *fileOverlay) ref() {
+	f.mutex.Lock()
+	f.refc++
+	f.mutex.Unlock()
+}
+
+func (f *fileOverlay) unref() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if f.refc--; f.refc == 0 {
+		closeIfNotNil(f.lower)
+		closeIfNotNil(f.upper)
+
+		if f.parent != nil {
+			f.parent.unref()
+		}
+	}
+}
+
+func ref(f *fileOverlay) {
+	if f != nil {
+		f.ref()
+	}
+}
+
+func unref(f *fileOverlay) {
+	if f != nil {
+		f.unref()
+	}
+}
+
+func closeIfNotNil(f sandbox.File) {
+	if f != nil {
+		f.Close()
+	}
+}
+
+type dirent struct {
+	typ  fs.FileMode
+	ino  uint64
+	name string
+}
+
+type dirOverlay struct {
+	mutex   sync.Mutex
+	index   int
+	offset  uint64
+	entries []dirent
+	error   error
+}
+
+func newDirOverlay() *dirOverlay {
+	return &dirOverlay{index: -1}
+}
+
+func (d *dirOverlay) init(lower, upper sandbox.File, buf []byte) error {
+	// The buffer received as argument is usually large enough to be used as
+	// scratch space to read entries from the underlying files, so we can avoid
+	// allocating a temporary buffer then. We clear the buffer when the function
+	// exits to make sure we don't leak details such as whiteout file names.
+	const minBufferSize = 2 * sandbox.PATH_MAX
+	if len(buf) < minBufferSize {
+		buf = make([]byte, minBufferSize)
+	} else {
+		defer clear(buf)
+	}
+
+	// We must keep track of all the names we have seen in the upper layer to
+	// be able to mask them from the lower layer.
+	names := make(map[string]struct{})
+	alloc := stringAllocator{}
+	for {
+		n, err := upper.ReadDirent(buf)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			break
+		}
+		for b := buf[:n]; len(b) > 0; {
+			n, typ, ino, _, ent, err := sandbox.ReadDirent(b)
+			if err != nil {
+				if err != io.ErrShortBuffer {
+					return err
+				}
+				break
+			}
+
+			b = b[n:]
+			name := alloc.makeString(ent)
+
+			if strings.HasPrefix(name, whiteoutPrefix) {
+				name = name[len(whiteoutPrefix):]
+			} else {
+				d.entries = append(d.entries, dirent{
+					typ:  typ,
+					ino:  ino,
+					name: name,
+				})
+			}
+
+			names[name] = struct{}{}
+		}
+	}
+
+	for {
+		n, err := lower.ReadDirent(buf)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			break
+		}
+		for b := buf[:n]; len(b) > 0; {
+			n, typ, ino, _, name, err := sandbox.ReadDirent(b)
+			if err != nil {
+				if err != io.ErrShortBuffer {
+					return err
+				}
+				break
+			}
+			if _, exist := names[string(name)]; !exist {
+				d.entries = append(d.entries, dirent{
+					typ:  typ,
+					ino:  ino,
+					name: alloc.makeString(name),
+				})
+			}
+			b = b[n:]
+		}
+	}
+
+	return nil
+}
+
+func (d *dirOverlay) reset() {
+	d.mutex.Lock()
+	if d.index > 0 {
+		d.index, d.offset = 0, 0
+	}
+	d.mutex.Unlock()
+}
+
+func (d *dirOverlay) readDirent(lower, upper sandbox.File, buf []byte) (n int, err error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	if d.error != nil {
+		return 0, d.error
+	}
+
+	if d.index < 0 {
+		d.index = 0
+		if err := d.init(lower, upper, buf); err != nil {
+			d.entries, d.error = nil, err
+			return 0, err
+		}
+	}
+
+	for d.index < len(d.entries) && n < len(buf) {
+		dirent := &d.entries[d.index]
+		wn := sandbox.WriteDirent(buf[n:], dirent.typ, dirent.ino, d.offset, dirent.name)
+		n += wn
+		if wn < sandbox.SizeOfDirent(len(dirent.name)) {
+			break
+		}
+		d.index++
+		d.offset += uint64(wn)
+	}
+
+	return n, nil
+}
+
+type stringAllocator struct {
+	buf []byte
+	off int
+}
+
+func (a *stringAllocator) makeString(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	if len(b) > 1024 {
+		return string(b)
+	}
+	if (len(a.buf) - a.off) < len(b) {
+		a.buf = make([]byte, 4096)
+		a.off = 0
+	}
+	i := a.off
+	j := a.off + len(b)
+	a.off = j
+	s := a.buf[i:j:j]
+	copy(s, b)
+	return unsafe.String(&s[0], len(s))
+}

--- a/internal/sandbox/overlayfs/overlayfs.go
+++ b/internal/sandbox/overlayfs/overlayfs.go
@@ -1,0 +1,42 @@
+package overlayfs
+
+import (
+	"io/fs"
+
+	"github.com/stealthrocket/timecraft/internal/sandbox"
+	"github.com/stealthrocket/timecraft/internal/sandbox/fspath"
+)
+
+type FileSystem struct {
+	lower sandbox.FileSystem
+	upper sandbox.FileSystem
+}
+
+func New(lower, upper sandbox.FileSystem) *FileSystem {
+	return &FileSystem{lower: lower, upper: upper}
+}
+
+func (fsys *FileSystem) Open(name string, flags sandbox.OpenFlags, mode fs.FileMode) (sandbox.File, error) {
+	f, err := fsys.openRoot()
+	if err != nil {
+		return nil, err
+	}
+	if fspath.IsRoot(name) {
+		return f, nil
+	}
+	defer f.Close()
+	return f.Open(name, flags, mode)
+}
+
+func (fsys *FileSystem) openRoot() (sandbox.File, error) {
+	lower, err := sandbox.OpenRoot(fsys.lower)
+	if err != nil {
+		return nil, err
+	}
+	upper, err := sandbox.OpenRoot(fsys.upper)
+	if err != nil {
+		lower.Close()
+		return nil, err
+	}
+	return newFile(newFileOverlay(nil, lower, upper, "/")), nil
+}

--- a/internal/sandbox/overlayfs/overlayfs_test.go
+++ b/internal/sandbox/overlayfs/overlayfs_test.go
@@ -1,0 +1,59 @@
+package overlayfs_test
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stealthrocket/timecraft/internal/sandbox"
+	"github.com/stealthrocket/timecraft/internal/sandbox/overlayfs"
+	"github.com/stealthrocket/timecraft/internal/sandbox/sandboxtest"
+)
+
+func TestOverlayFS(t *testing.T) {
+	t.Run("sandbox.FileSystem", func(t *testing.T) {
+		sandboxtest.TestFileSystem(t, func(t *testing.T) sandbox.FileSystem {
+			lower := sandbox.DirFS(t.TempDir())
+			upper := sandbox.DirFS(t.TempDir())
+			return overlayfs.New(lower, upper)
+		})
+	})
+
+	tests := []struct {
+		scenario string
+		makeFS   func(*testing.T, string) sandbox.FileSystem
+	}{
+		{
+			scenario: "FS in lower layer",
+			makeFS: func(t *testing.T, path string) sandbox.FileSystem {
+				return overlayfs.New(
+					sandbox.DirFS(path),
+					sandbox.DirFS(t.TempDir()),
+				)
+			},
+		},
+
+		{
+			scenario: "FS in upper layer",
+			makeFS: func(t *testing.T, path string) sandbox.FileSystem {
+				return overlayfs.New(
+					sandbox.DirFS(t.TempDir()),
+					sandbox.DirFS(path),
+				)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.scenario, func(t *testing.T) {
+			t.Run("fs.FS", func(t *testing.T) {
+				sandboxtest.TestFS(t, func(t *testing.T, path string) fs.FS {
+					return sandbox.FS(test.makeFS(t, path))
+				})
+			})
+
+			sandboxtest.TestRootFS(t, func(t *testing.T, path string) sandbox.FileSystem {
+				return test.makeFS(t, path)
+			})
+		})
+	}
+}

--- a/internal/sandbox/overlayfs/overlayfs_test.go
+++ b/internal/sandbox/overlayfs/overlayfs_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"testing"
 
+	"github.com/stealthrocket/timecraft/internal/assert"
 	"github.com/stealthrocket/timecraft/internal/sandbox"
 	"github.com/stealthrocket/timecraft/internal/sandbox/overlayfs"
 	"github.com/stealthrocket/timecraft/internal/sandbox/sandboxtest"
@@ -56,4 +57,171 @@ func TestOverlayFS(t *testing.T) {
 			})
 		})
 	}
+
+	specTests := []struct {
+		scenario string
+		function func(*testing.T, sandbox.FileSystem, sandbox.FileSystem)
+	}{
+		{
+			scenario: "removed files that existed in the lower layer do no appear in the overlay file system",
+			function: testOverlayFSUnlinkFile,
+		},
+
+		{
+			scenario: "removed files that existed in a sub directory of the lower layer do no appear in the overlay file system",
+			function: testOverlayFSUnlinkFileInDirectory,
+		},
+
+		{
+			scenario: "recreating a file at a location that was removed from the lower layer and removing it does not cause the lower file to reappear",
+			function: testOverlayFSUnlinkAndCreateAndUnlink,
+		},
+
+		{
+			scenario: "unlinking a directory that exists in the lower layer errors with EISDIR",
+			function: testOverlayFSUnlinkDirectory,
+		},
+
+		{
+			scenario: "a file can be create in place where one existed in the lower layer",
+			function: testOverlayFSCreateOverwrite,
+		},
+
+		{
+			scenario: "a file can be create in place where one was removed in the lower layer",
+			function: testOverlayFSCreateAfterUnlink,
+		},
+
+		{
+			scenario: "creating a file with O_EXCL at a location that exists on the lower layer errors with EEXIST",
+			function: testOverlayFSCreateExclusiveExists,
+		},
+	}
+
+	for _, test := range specTests {
+		t.Run(test.scenario, func(t *testing.T) {
+			test.function(t,
+				sandbox.DirFS(t.TempDir()),
+				sandbox.DirFS(t.TempDir()),
+			)
+		})
+	}
+}
+
+func testOverlayFSUnlinkFile(t *testing.T, lower, upper sandbox.FileSystem) {
+	foo, err := sandbox.Create(lower, "foo", 0644)
+	assert.OK(t, err)
+	assert.OK(t, foo.Close())
+
+	bar, err := sandbox.Create(lower, "bar", 0644)
+	assert.OK(t, err)
+	assert.OK(t, bar.Close())
+
+	fsys := overlayfs.New(lower, upper)
+	assert.OK(t, sandbox.Unlink(fsys, "foo"))
+
+	_, err = sandbox.Open(fsys, "foo")
+	assert.Error(t, err, sandbox.ENOENT)
+
+	_, err = sandbox.Stat(fsys, "foo")
+	assert.Error(t, err, sandbox.ENOENT)
+
+	_, err = sandbox.Stat(fsys, "bar")
+	assert.OK(t, err)
+}
+
+func testOverlayFSUnlinkFileInDirectory(t *testing.T, lower, upper sandbox.FileSystem) {
+	err := sandbox.MkdirAll(lower, "path/to", 0755)
+	assert.OK(t, err)
+
+	foo, err := sandbox.Create(lower, "path/to/foo", 0644)
+	assert.OK(t, err)
+	assert.OK(t, foo.Close())
+
+	bar, err := sandbox.Create(lower, "path/to/bar", 0644)
+	assert.OK(t, err)
+	assert.OK(t, bar.Close())
+
+	fsys := overlayfs.New(lower, upper)
+	assert.OK(t, sandbox.Unlink(fsys, "path/to/foo"))
+
+	_, err = sandbox.Open(fsys, "path/to/foo")
+	assert.Error(t, err, sandbox.ENOENT)
+
+	_, err = sandbox.Stat(fsys, "path/to/foo")
+	assert.Error(t, err, sandbox.ENOENT)
+
+	_, err = sandbox.Stat(fsys, "path/to/bar")
+	assert.OK(t, err)
+}
+
+func testOverlayFSUnlinkAndCreateAndUnlink(t *testing.T, lower, upper sandbox.FileSystem) {
+	foo, err := sandbox.Create(lower, "foo", 0644)
+	assert.OK(t, err)
+	assert.OK(t, foo.Close())
+
+	fsys := overlayfs.New(lower, upper)
+	assert.OK(t, sandbox.Unlink(fsys, "foo"))
+
+	f, err := sandbox.Create(fsys, "foo", 0644)
+	assert.OK(t, err)
+	assert.OK(t, f.Close())
+	assert.OK(t, sandbox.Unlink(fsys, "foo"))
+
+	_, err = sandbox.Open(fsys, "foo")
+	assert.Error(t, err, sandbox.ENOENT)
+
+	_, err = sandbox.Stat(fsys, "foo")
+	assert.Error(t, err, sandbox.ENOENT)
+}
+
+func testOverlayFSUnlinkDirectory(t *testing.T, lower, upper sandbox.FileSystem) {
+	err := sandbox.Mkdir(lower, "test", 0755)
+	assert.OK(t, err)
+
+	fsys := overlayfs.New(lower, upper)
+
+	err = sandbox.Unlink(fsys, "test")
+	assert.Error(t, err, sandbox.EISDIR)
+}
+
+func testOverlayFSCreateOverwrite(t *testing.T, lower, upper sandbox.FileSystem) {
+	err := sandbox.WriteFile(lower, "test", []byte("foo"), 0644)
+	assert.OK(t, err)
+
+	fsys := overlayfs.New(lower, upper)
+
+	err = sandbox.Unlink(fsys, "test")
+	assert.OK(t, err)
+
+	err = sandbox.WriteFile(fsys, "test", []byte("bar"), 0644)
+	assert.OK(t, err)
+
+	b, err := sandbox.ReadFile(fsys, "test", 0)
+	assert.OK(t, err)
+	assert.Equal(t, string(b), "bar")
+}
+
+func testOverlayFSCreateAfterUnlink(t *testing.T, lower, upper sandbox.FileSystem) {
+	err := sandbox.WriteFile(lower, "test", []byte("foo"), 0644)
+	assert.OK(t, err)
+
+	fsys := overlayfs.New(lower, upper)
+
+	err = sandbox.WriteFile(fsys, "test", []byte("bar"), 0644)
+	assert.OK(t, err)
+
+	b, err := sandbox.ReadFile(fsys, "test", 0)
+	assert.OK(t, err)
+	assert.Equal(t, string(b), "bar")
+}
+
+func testOverlayFSCreateExclusiveExists(t *testing.T, lower, upper sandbox.FileSystem) {
+	err := sandbox.WriteFile(lower, "test", []byte("foo"), 0644)
+	assert.OK(t, err)
+
+	fsys := overlayfs.New(lower, upper)
+
+	_, err = fsys.Open("test", sandbox.O_CREAT|sandbox.O_EXCL|sandbox.O_RDWR, 0644)
+	assert.Error(t, err, sandbox.EEXIST)
 }

--- a/internal/sandbox/sandboxtest/fs_unlink.go
+++ b/internal/sandbox/sandboxtest/fs_unlink.go
@@ -44,6 +44,28 @@ var fsTestUnlink = fsTestSuite{
 		assert.Error(t, err, sandbox.ENOENT)
 	},
 
+	"unlinking a file in a sub directory deletes it from the file system": func(t *testing.T, fsys sandbox.FileSystem) {
+		err := sandbox.MkdirAll(fsys, "tmp", 0755)
+		assert.OK(t, err)
+
+		err = sandbox.WriteFile(fsys, "tmp/test", []byte("123"), 0600)
+		assert.OK(t, err)
+
+		b, err := sandbox.ReadFile(fsys, "tmp/test", 0)
+		assert.OK(t, err)
+		assert.Equal(t, string(b), "123")
+
+		err = sandbox.Unlink(fsys, "tmp/test")
+		assert.OK(t, err)
+
+		_, err = sandbox.ReadFile(fsys, "tmp/test", 0)
+		assert.Error(t, err, sandbox.ENOENT)
+
+		s, err := sandbox.Stat(fsys, "tmp")
+		assert.OK(t, err)
+		assert.Equal(t, s.Mode.IsDir(), true)
+	},
+
 	"unlinking a symlink deletes it from the file system": func(t *testing.T, fsys sandbox.FileSystem) {
 		err := sandbox.Symlink(fsys, "test", "link")
 		assert.OK(t, err)

--- a/internal/sandbox/syscall_unix.go
+++ b/internal/sandbox/syscall_unix.go
@@ -542,3 +542,9 @@ func WriteDirent(buf []byte, typ fs.FileMode, ino, off uint64, name string) int 
 	}
 	return n
 }
+
+// SizeOfDirent returns the size of a directory entry with a name of the given
+// length.
+func SizeOfDirent(nameLen int) int {
+	return sizeOfDirent + nameLen + 1
+}

--- a/internal/sandbox/tarfs/dir.go
+++ b/internal/sandbox/tarfs/dir.go
@@ -26,7 +26,7 @@ type dir struct {
 func newDir(header *tar.Header) *dir {
 	mode := header.FileInfo().Mode()
 	return &dir{
-		perm:  mode.Perm() & 0555,
+		perm:  mode.Perm(),
 		mtime: header.ModTime.UnixNano(),
 		atime: header.AccessTime.UnixNano(),
 		ctime: header.ChangeTime.UnixNano(),
@@ -35,7 +35,7 @@ func newDir(header *tar.Header) *dir {
 
 func makeDir(modTime time.Time) dir {
 	return dir{
-		perm:  0555,
+		perm:  0755,
 		mtime: modTime.UnixNano(),
 		atime: modTime.UnixNano(),
 		ctime: modTime.UnixNano(),
@@ -293,4 +293,4 @@ func (*openDir) Readv([][]byte) (int, error) { return 0, sandbox.EISDIR }
 
 func (*openDir) Preadv([][]byte, int64) (int, error) { return 0, sandbox.EISDIR }
 
-func (*openDir) CopyFileRange(int64, sandbox.File, int64, int) (int, error) { return 0, sandbox.EISDIR }
+func (*openDir) CopyRange(int64, sandbox.File, int64, int) (int, error) { return 0, sandbox.EISDIR }

--- a/internal/sandbox/tarfs/file.go
+++ b/internal/sandbox/tarfs/file.go
@@ -27,10 +27,9 @@ type file struct {
 
 func newFile(header *tar.Header, offset int64) *file {
 	info := header.FileInfo()
-	mode := info.Mode()
 	return &file{
-		perm:   mode.Perm() & 0555,
 		nlink:  1,
+		perm:   info.Mode().Perm(),
 		size:   info.Size(),
 		mtime:  header.ModTime.UnixNano(),
 		atime:  header.AccessTime.UnixNano(),
@@ -151,7 +150,7 @@ func (f *openFile) Preadv(buf [][]byte, off int64) (int, error) {
 	return read, nil
 }
 
-func (f *openFile) CopyFileRange(srcOffset int64, dst sandbox.File, dstOffset int64, length int) (int, error) {
+func (f *openFile) CopyRange(srcOffset int64, dst sandbox.File, dstOffset int64, length int) (int, error) {
 	file := f.file.Load()
 	if file == nil {
 		return 0, sandbox.EBADF
@@ -172,7 +171,7 @@ func (f *openFile) CopyFileRange(srcOffset int64, dst sandbox.File, dstOffset in
 		}
 	}
 
-	return sandbox.CopyFileRange(f, srcOffset, dst, dstOffset, length)
+	return sandbox.FileCopyRange(f, srcOffset, dst, dstOffset, length)
 }
 
 func (f *openFile) Seek(offset int64, whence int) (int64, error) {

--- a/internal/sandbox/tarfs/placeholder.go
+++ b/internal/sandbox/tarfs/placeholder.go
@@ -17,11 +17,10 @@ type placeholder struct {
 
 func newPlaceholder(header *tar.Header) *placeholder {
 	info := header.FileInfo()
-	mode := info.Mode()
 	return &placeholder{
 		info: sandbox.FileInfo{
 			Size:  info.Size(),
-			Mode:  mode.Type() | (mode.Perm() & 0555),
+			Mode:  info.Mode(),
 			Uid:   1,
 			Gid:   1,
 			Nlink: 1,

--- a/internal/sandbox/tarfs/symlink.go
+++ b/internal/sandbox/tarfs/symlink.go
@@ -19,9 +19,9 @@ type symlink struct {
 }
 
 func newSymlink(header *tar.Header) *symlink {
-	mode := header.FileInfo().Mode()
+	info := header.FileInfo()
 	return &symlink{
-		perm:  mode.Perm() & 0555,
+		perm:  info.Mode().Perm(),
 		nlink: 1,
 		mtime: header.ModTime.UnixNano(),
 		atime: header.AccessTime.UnixNano(),

--- a/internal/sandbox/tarfs/tarfs_test.go
+++ b/internal/sandbox/tarfs/tarfs_test.go
@@ -26,7 +26,7 @@ func TestTarFS(t *testing.T) {
 
 	sandboxtest.TestRootFS(t, makeTarFS)
 
-	t.Run("CopyFileRange", func(t *testing.T) {
+	t.Run("CopyRange", func(t *testing.T) {
 		tmp := t.TempDir()
 		tmpFS := sandbox.DirFS(tmp)
 		assert.OK(t, sandbox.WriteFile(tmpFS, "src", []byte("Hello World!"), 0644))
@@ -41,7 +41,7 @@ func TestTarFS(t *testing.T) {
 		assert.OK(t, err)
 		defer dstFile.Close()
 
-		_, err = srcFile.CopyFileRange(0, dstFile, 0, 12)
+		_, err = srcFile.CopyRange(0, dstFile, 0, 12)
 		assert.OK(t, err)
 		assert.OK(t, dstFile.Close())
 
@@ -103,7 +103,7 @@ func TestAlpine(t *testing.T) {
 	// Also verify that the metadata for the file is what we expected.
 	s, err := sandbox.Stat(fsys, "/usr/share/apk/keys/aarch64/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub")
 	assert.OK(t, err)
-	assert.Equal(t, s.Mode, 0444)
+	assert.Equal(t, s.Mode, 0644)
 	assert.Equal(t, s.Size, 451)
 
 	size, memsize, filesize := fsys.Size(), fsys.Memsize(), fsys.Filesize()


### PR DESCRIPTION
This PR adds a new implementation of the `sandbox.FileSystem` interface, which implements a behavior similar to the Linux overlay file system: combining two file system layers, a lower read layer, and an upper write layer. The lower layer defines the initial state of the file system, while the upper layer serves all writes. When a write happens, the data is lazily moved from the lower to the upper layer to serve the writes.

A significant challenge of implementing such a file system is managing permissions on directories because read-only or non-searchable directories copied to the write layer will prevent migrating files from the read layer (if they are read-only, no files can be created). I left this out for now since we don't have a use case for it in WASI (there are no Unix-style permissions), and documented this reasoning in the code.

Another challenge is removing files migrated from the read to the write layer. Simply deleting the file entry on the write layer would cause the file to be reset to its original state since the file in the read layer would become visible again. For this reason, we use the same strategy we do for the OCI layers and create a whiteout file instead of deleting the directory entry so it keeps masking the content of the read layer.

Lastly, the current implementation doesn't scale when writing to very large files that exist on the read layer because we copy the entire file to the write layer before serving the write. I don't know of any use cases for this, it should be rarely needed. Still, if we ever needed to, we could improve the implementation using sparse files on the upper layer to move only areas of the file that have been touched (note that some file systems will already optimize `copy_file_range`, which we use to migrate files to the write layer, in which case the copy isn't much of a concern).