### PR TITLE
ocifs: read-write layers

### DIFF
--- a/internal/sandbox/dirfs_unix.go
+++ b/internal/sandbox/dirfs_unix.go
@@ -143,7 +143,7 @@ func (f *dirFile) openFile(name string, flags OpenFlags, mode fs.FileMode) (File
 }
 
 func (f *dirFile) Open(name string, flags OpenFlags, mode fs.FileMode) (File, error) {
-	return FileOpen(f, name, flags, ^OpenFlags(0), mode,
+	return FileOpen(f, name, flags, mode,
 		(*dirFile).openRoot,
 		(*dirFile).openSelf,
 		(*dirFile).openParent,

--- a/internal/sandbox/fs.go
+++ b/internal/sandbox/fs.go
@@ -523,8 +523,7 @@ type File interface {
 // common parts of the Open logic, for example:
 //
 //	func (f *file) Open(name string, flags OpenFlags, mode fs.FileMode) (File, error) {
-//		const supportedFlags = ^OpenFlags(0)
-//		return FileOpen(f, name, flags, supportedFlags, mode,
+//		return FileOpen(f, name, flags, mode,
 //			(*file).openRoot,
 //			(*file).openSelf,
 //			(*file).openParent,
@@ -535,13 +534,13 @@ type File interface {
 // The function performs path resolution and invokes one of the callbacks passed
 // as arguments to navigate the directory tree and eventually open and return the
 // final target.
-func FileOpen[F File](f F, name string, flags, supportedFlags OpenFlags, mode fs.FileMode,
+func FileOpen[F File](f F, name string, flags OpenFlags, mode fs.FileMode,
 	openRoot func(F) (File, error),
 	openSelf func(F) (File, error),
 	openParent func(F) (File, error),
 	openFile func(F, string, OpenFlags, fs.FileMode) (File, error),
 ) (File, error) {
-	if (flags & ^supportedFlags) != 0 || name == "" {
+	if name == "" {
 		return nil, EINVAL
 	}
 	if fspath.IsRoot(name) {

--- a/internal/sandbox/ocifs/ocifs.go
+++ b/internal/sandbox/ocifs/ocifs.go
@@ -17,9 +17,15 @@ type FileSystem struct {
 // New constructs a file system which combines layers into a flattened view
 // which stacks layers on each other.
 //
-// The returned file system is read-only, it does not allow modifications of
-// the layers that it was constructed from. This includes writes to files as
-// well as modifcations of the directory structure.
+// The returned file system delegates file and directory operations to the
+// layers that it is composed of. If a layer is read-only, attempting to mutate
+// its directory structure of file(s) content will be forbidden, but if a layer
+// allows mutations, the application may create, update, or remove entries in
+// that layer. Keep in mind that mutating layers can create unexpected
+// situations such as files from lower layers "reappearing" after an entry was
+// deleted in an upper layer; for this reason, it is often preferrable to mask
+// mutable parts of the file system using an opaque layer (such as a file system
+// returned by ocifs.Opaque).
 //
 // For the OCI layer specification, see:
 // https://github.com/opencontainers/image-spec/blob/main/layer.md

--- a/internal/sandbox/ocifs/ocifs_test.go
+++ b/internal/sandbox/ocifs/ocifs_test.go
@@ -59,6 +59,15 @@ func TestOciFS(t *testing.T) {
 			sandboxtest.TestRootFS(t, test.makeFS)
 		})
 	}
+
+	t.Run("sandbox.FileSystem", func(t *testing.T) {
+		sandboxtest.TestFileSystem(t, func(t *testing.T) sandbox.FileSystem {
+			return ocifs.New(
+				sandbox.DirFS(t.TempDir()), // empty layer, should be ignored by the test
+				sandbox.DirFS(t.TempDir()), // layer receiving mutations during the test
+			)
+		})
+	})
 }
 
 func TestOciFSLayers(t *testing.T) {

--- a/internal/sandbox/subfs.go
+++ b/internal/sandbox/subfs.go
@@ -130,7 +130,7 @@ func (f *subFile) openFile(name string, flags OpenFlags, mode fs.FileMode) (File
 }
 
 func (f *subFile) Open(name string, flags OpenFlags, mode fs.FileMode) (File, error) {
-	return FileOpen(f, name, flags, ^OpenFlags(0), mode,
+	return FileOpen(f, name, flags, mode,
 		(*subFile).openRoot,
 		(*subFile).openSelf,
 		(*subFile).openParent,


### PR DESCRIPTION
Following up on #229, this PR makes the OCI layered file system writable if the underlying layers can be written. This allows the application to mutate the content of file systems mounted at specific locations with `sandbox.SubFS`.

While technically, this enables the use cases we're trying to implement (read-only file system + writable mount points), I'm feeling increasingly uneasy about this being somewhat of a workaround for the lack of a more general-purpose copy-on-write mechanism; I'm hoping we'll find the time to get back to working on this at some point: this model only works if the mount points are made opaque (e.g. masking files from layers below) because otherwise the application may end up in very strange situations where it can create directory entries in the writable layer but cannot mutate some of the entries seen from the layers below etc... as long as we apply strong controls over how the file systems are constructed we shouldn't run into too many issues, but it still feels like living on borrowed time.